### PR TITLE
Support Multiple Contract Configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Tool used for computing vanity Safe addresses.
 
-This tool is currently hard-coded to only support the [`v1.4.1`](https://github.com/safe-global/safe-deployments/tree/9cf5d5f75819371b7b63fcc66f316bcd920f3c58/src/assets/v1.4.1) Safe deployment:
+This tool only officially supports the latest Safe deployment [`v1.4.1`](https://github.com/safe-global/safe-deployments/tree/9cf5d5f75819371b7b63fcc66f316bcd920f3c58/src/assets/v1.4.1).
+For Ethereum:
 - `SafeProxyFactory` [`0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67`](https://etherscan.io/address/0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67)
 - `Safe` [`0x41675C099F32341bf84BFc5382aF534df5C7461a`](https://etherscan.io/address/0x41675C099F32341bf84BFc5382aF534df5C7461a)
 - `CompatibilityFallbackHandler` [`0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99`](https://etherscan.io/address/0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99)
@@ -13,6 +14,7 @@ It works by randomly trying out different values for the `saltNonce` parameter u
 ## Building
 
 For longer prefixes, this can take a **very** long time, so be sure to build with release:
+
 ```
 cargo build --release
 ```
@@ -33,11 +35,13 @@ deadbeef \
 ```
 
 Note that the owner signature threshold defaults to 1 but can optionally be specified with:
+
 ```
 deadbeef ... --threshold 2 ...
 ```
 
 This will output some result like:
+
 ```
 address:   0xdEADBEefEAFbe3622E000Fda70bBF742dDDEbC71
 factory:   0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67
@@ -48,6 +52,34 @@ owners:    0x1111111111111111111111111111111111111111
 threshold: 1
 calldata:  0x1688f0b900000000000000000000000041675c099f32341bf84bfc5382af534df5c7461a0000000000000000000000000000000000000000000000000000000000000060e4cf27da52614adef0b22f15b975c956927faa0ab22fa1f1a82db0760a9ddddd0000000000000000000000000000000000000000000000000000000000000184b63e800d0000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000160000000000000000000000000fd0732dc9e303f09fcef3a7388ad10a83459ec99000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000011111111111111111111111111111111111111110000000000000000000000002222222222222222222222222222222222222222000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
 ```
+
+For using Safe deployments on different chains can also be used:
+
+```
+deadbeef ... --chain 100 ...
+```
+
+As well as custom fallback handlers:
+
+```
+deadbeef ... --fallback-handler 0x4e305935b14627eA57CBDbCfF57e81fd9F240403 ...
+```
+
+## Unsupported Chains
+
+Safe deployments on non-officially supported networks can also be used by overriding all contract addresses and the proxy init code:
+
+```
+deadbeef ... \
+  --chain $UNSUPPORTED_CHAIN \
+  --proxy-factory 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  --proxy-init-code 0xbb \
+  --singleton 0xcccccccccccccccccccccccccccccccccccccccc \
+  --fallback-handler 0xdddddddddddddddddddddddddddddddddddddddd
+```
+
+**Use this with caution**, this assumes that the proxy address is computed in the exact same was as on Ethereum, which may not be the case for all networks.
+This feature is not officially supported by the tool.
 
 ## Creating the Safe
 

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,0 +1,82 @@
+//! Module for chain-specific data.
+
+use crate::{address::address, safe::Contracts};
+use hex_literal::hex;
+use std::{
+    fmt::{self, Display, Formatter},
+    num::ParseIntError,
+    str::FromStr,
+};
+
+/// A Safe supported chain.
+#[derive(Clone, Copy, Debug)]
+pub struct Chain(u128);
+
+impl Chain {
+    /// Returns a [`Chain`] for Ethereum Mainnet.
+    pub const fn ethereum() -> Self {
+        Self(1)
+    }
+
+    /// Returns the [`Contracts`] for this chain, or `None` if the chain is not
+    /// supported.
+    pub fn contracts(&self) -> Option<Contracts> {
+        // Addresses can be found in the Safe deployments repository:
+        // <https://github.com/safe-global/safe-deployments/tree/main/src/assets/v1.4.1>
+        // The `proxyCreationCode` can be read from the from the proxy factory:
+        // <https://etherscan.io/address/0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67>
+        match self.0 {
+            1 | 100 => Some(Contracts {
+                proxy_factory: address!("4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67"),
+                proxy_init_code: hex!(
+                    "608060405234801561001057600080fd5b506040516101e63803806101e68339
+                     818101604052602081101561003357600080fd5b810190808051906020019092
+                     9190505050600073ffffffffffffffffffffffffffffffffffffffff168173ff
+                     ffffffffffffffffffffffffffffffffffffff1614156100ca576040517f08c3
+                     79a0000000000000000000000000000000000000000000000000000000008152
+                     6004018080602001828103825260228152602001806101c46022913960400191
+                     505060405180910390fd5b806000806101000a81548173ffffffffffffffffff
+                     ffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffff
+                     ffffffffff1602179055505060ab806101196000396000f3fe608060405273ff
+                     ffffffffffffffffffffffffffffffffffffff600054167fa619486e00000000
+                     0000000000000000000000000000000000000000000000006000351415605057
+                     8060005260206000f35b3660008037600080366000845af43d6000803e600081
+                     14156070573d6000fd5b3d6000f3fea264697066735822122003d1488ee65e08
+                     fa41e58e888a9865554c535f2c77126a82cb4c0f917f31441364736f6c634300
+                     07060033496e76616c69642073696e676c65746f6e2061646472657373207072
+                     6f7669646564"
+                )
+                .to_vec(),
+                singleton: address!("41675C099F32341bf84BFc5382aF534df5C7461a"),
+                fallback_handler: address!("fd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99"),
+            }),
+            _ => None,
+        }
+    }
+}
+
+impl Default for Chain {
+    fn default() -> Self {
+        Self::ethereum()
+    }
+}
+
+impl Display for Chain {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for Chain {
+    type Err = ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (s, radix) = match s.strip_prefix("0x") {
+            Some(s) => (s, 16),
+            None => (s, 10),
+        };
+        let value = u128::from_str_radix(s, radix)?;
+
+        Ok(Self(value))
+    }
+}

--- a/src/create2.rs
+++ b/src/create2.rs
@@ -11,14 +11,14 @@ impl Create2 {
     /// Creates a new instance with the specified parameters.
     pub fn new(factory: Address, salt: [u8; 32], init_code: [u8; 32]) -> Self {
         let mut create2 = Self([0xff_u8; 85]);
-        create2.factory_mut().copy_from_slice(&factory.0);
-        create2.salt_mut().copy_from_slice(&salt);
-        create2.init_code_mut().copy_from_slice(&init_code);
+        *create2.factory_mut() = factory;
+        *create2.salt_mut() = salt;
+        *create2.init_code_mut() = init_code;
         create2
     }
 
     /// Returns the slice representing the factory.
-    pub fn factory_mut(&mut self) -> &mut [u8; 20] {
+    pub fn factory_mut(&mut self) -> &mut Address {
         unsafe { &mut *self.0.get_unchecked_mut(1..21).as_mut_ptr().cast() }
     }
 
@@ -59,7 +59,7 @@ mod tests {
                 hex!("96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f")
             )
             .creation_address(),
-            address!("3e8468f66d30fc99f745481d4b383f89861702c6"),
+            address!("3e8468f66d30Fc99F745481d4B383f89861702C6"),
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,14 @@
 mod address;
+mod chain;
 mod create2;
 mod safe;
 
 use crate::{address::Address, safe::Safe};
+use chain::Chain;
 use clap::Parser;
 use hex::FromHexError;
 use rand::{rngs::SmallRng, Rng as _, SeedableRng as _};
-use safe::Info;
+use safe::{Contracts, Info};
 use std::{process, str::FromStr, sync::mpsc, thread};
 
 /// Generate vanity addresses for Safe deployments.
@@ -27,6 +29,28 @@ struct Args {
     #[arg(short, long)]
     prefix: Hex,
 
+    /// The chain ID to find a vanity Safe address for. If the chain is not
+    /// supported, then all of '--proxy-factory', '--proxy-init-code',
+    /// '--singleton' and '--fallback-handler' must be specified.
+    #[arg(short, long, default_value_t = Chain::ethereum())]
+    chain: Chain,
+
+    /// Override for the `SafeProxyFactory` address.
+    #[arg(long)]
+    proxy_factory: Option<Address>,
+
+    /// Override for the `SafeProxy` init code.
+    #[arg(long)]
+    proxy_init_code: Option<Hex>,
+
+    /// Override for the `Safe` singleton address.
+    #[arg(long)]
+    singleton: Option<Address>,
+
+    /// Override for the Safe fallback handler address.
+    #[arg(long)]
+    fallback_handler: Option<Address>,
+
     /// Quiet mode.
     ///
     /// Only output the transaction calldata without any extra information.
@@ -34,7 +58,7 @@ struct Args {
     quiet: bool,
 }
 
-/// Helper type for parsing hexadecimal input from the command line.
+/// Helper type for parsing hexadecimal byte input from the command line.
 #[derive(Clone)]
 struct Hex(Vec<u8>);
 
@@ -49,11 +73,34 @@ impl FromStr for Hex {
 fn main() {
     let args = Args::parse();
 
+    let contracts = args
+        .chain
+        .contracts()
+        .map(|contracts| Contracts {
+            proxy_factory: args.proxy_factory.unwrap_or(contracts.proxy_factory),
+            proxy_init_code: args
+                .proxy_init_code
+                .clone()
+                .map(|hex| hex.0)
+                .unwrap_or(contracts.proxy_init_code),
+            singleton: args.singleton.unwrap_or(contracts.singleton),
+            fallback_handler: args.fallback_handler.unwrap_or(contracts.fallback_handler),
+        })
+        .or_else(|| {
+            Some(Contracts {
+                proxy_factory: args.proxy_factory?,
+                proxy_init_code: args.proxy_init_code?.0,
+                singleton: args.singleton?,
+                fallback_handler: args.fallback_handler?,
+            })
+        })
+        .expect("unsupported chain");
+
     let (sender, receiver) = mpsc::channel();
     let threads = (0..num_cpus::get())
         .map(|_| {
             thread::spawn({
-                let safe = Safe::new(args.owners.clone(), args.threshold);
+                let safe = Safe::new(contracts.clone(), args.owners.clone(), args.threshold);
                 let prefix = args.prefix.0.clone();
                 let result = sender.clone();
                 move || search_vanity_safe(safe, &prefix, result)


### PR DESCRIPTION
This PR adds support for additional chains where the Safe address is computed in the same way as Ethereum. For this, we add a `--chain` configuration for specifying a new chain. Since v1.4.1 is only released on Mainnet and Gnosis Chain, only those two chains are supported for now.

Additionally, there are new parameters to completely override all chain-specific data (contract addresses and init codes) as an "officially unsupported escape hatch".