### PR TITLE
Refactor Into Library and Binary Crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,12 +125,20 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "deadbeef"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
+ "deadbeef-core",
+ "hex",
+ "num_cpus",
+]
+
+[[package]]
+name = "deadbeef-core"
+version = "0.1.0"
+dependencies = [
  "hex",
  "hex-literal",
- "num_cpus",
  "rand",
  "tiny-keccak",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,5 @@
-[package]
-name = "deadbeef"
-version = "0.1.0"
-edition = "2021"
-publish = false
-license = "GPL-3.0-or-later"
-
-[dependencies]
-clap = { version = "4", features = ["derive"] }
-hex = "0.4"
-hex-literal = "0.4"
-num_cpus = "1"
-rand = { version = "0.8", features = ["small_rng"] }
-tiny-keccak = { version = "2", features = ["keccak"] }
+[workspace]
+members = [
+  "cli",
+  "core",
+]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "deadbeef"
+version = "0.1.1"
+edition = "2021"
+publish = false
+license = "GPL-3.0-or-later"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+deadbeef-core = { version = "0.1.0", path = "../core" }
+hex = "0.4"
+num_cpus = "1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "deadbeef-core"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "GPL-3.0-or-later"
+
+[dependencies]
+hex = "0.4"
+hex-literal = "0.4"
+rand = { version = "0.8", features = ["small_rng"] }
+tiny-keccak = { version = "2", features = ["keccak"] }

--- a/core/src/address.rs
+++ b/core/src/address.rs
@@ -72,13 +72,12 @@ impl FromStr for Address {
     }
 }
 
+#[macro_export]
 macro_rules! address {
     ($s:literal) => {
-        $crate::address::Address(::hex_literal::hex!($s))
+        $crate::Address($crate::hex!($s))
     };
 }
-
-pub(crate) use address;
 
 #[cfg(test)]
 mod tests {

--- a/core/src/create2.rs
+++ b/core/src/create2.rs
@@ -45,7 +45,6 @@ impl Create2 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::address::address;
     use hex_literal::hex;
 
     #[test]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,0 +1,20 @@
+#[macro_use]
+mod address;
+mod create2;
+mod safe;
+
+pub use self::{
+    address::Address,
+    safe::{Contracts, Safe, Transaction},
+};
+pub use hex_literal::hex;
+use rand::{rngs::SmallRng, Rng as _, SeedableRng as _};
+
+/// For the specified Safe parameters
+pub fn search(mut safe: Safe, prefix: &[u8]) -> Transaction {
+    let mut rng = SmallRng::from_entropy();
+    while !safe.creation_address().0.starts_with(prefix) {
+        safe.update_salt_nonce(|n| rng.fill(n));
+    }
+    safe.transaction()
+}


### PR DESCRIPTION
This PR refactors `deadbeef` into separate binary and library crates. This makes producing additional `deadbeef` targets (for WASM for example, see #5) possible.