### PR TITLE
Allow odd length prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+release

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -65,21 +65,32 @@ impl FromStr for Hex {
     }
 }
 
+// returns a vector of u8 nibbles from a hex string
+// if the hex string is of odd length, the first 4 bits of each u8 will be 0
+// if the hex string is of even length, each u8 will be split into two nibbles
 fn hex_to_nibbles(hex_str: &str) -> Result<Vec<u8>, std::num::ParseIntError> {
     let cleaned = if hex_str.starts_with("0x") {
         &hex_str[2..]
     } else {
         hex_str
     };
-
-    cleaned.chars().map(|c| u8::from_str_radix(&c.to_string(), 16)).collect()
+    if hex_str.len() % 2 != 0 {
+        cleaned.chars().map(|c| u8::from_str_radix(&c.to_string(), 16)).collect()
+    } else {
+        (0..cleaned.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&cleaned[i..i + 2], 16))
+        .collect()
+    }
 }
 
 fn main() {
     let args = Args::parse();
 
-    let prefix_nibbles = hex_to_nibbles(&args.prefix)
+    let prefix = hex_to_nibbles(&args.prefix)
         .expect("Failed to decode hex string"); 
+
+    let is_odd_length = args.prefix.len() % 2 != 0;
 
     let contracts = args
         .chain
@@ -109,10 +120,10 @@ fn main() {
         .map(|_| {
             thread::spawn({
                 let mut safe = Safe::new(contracts.clone(), args.owners.clone(), args.threshold);
-                let prefix = prefix_nibbles.clone();
+                let prefix = prefix.clone();
                 let result = sender.clone();
                 move || {
-                    deadbeef_core::search(&mut safe, &prefix);
+                    deadbeef_core::search(&mut safe, &prefix, is_odd_length);
                     let _ = result.send(safe);
                 }
             })

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,7 +13,16 @@ use rand::{rngs::SmallRng, Rng as _, SeedableRng as _};
 /// Search for a vanity address with the specified Safe parameters and prefix.
 pub fn search(safe: &mut Safe, prefix: &[u8]) {
     let mut rng = SmallRng::from_entropy();
-    while !safe.creation_address().0.starts_with(prefix) {
+    while !starts_with_nibbles(&safe.creation_address().0[..], prefix) {
         safe.update_salt_nonce(|n| rng.fill(n));
     }
+}
+
+fn starts_with_nibbles(data: &[u8], prefix_nibbles: &[u8]) -> bool {
+    let data_nibbles: Vec<u8> = data
+        .iter()
+        .flat_map(|&byte| vec![byte >> 4, byte & 0x0F])
+        .collect();
+
+    data_nibbles.starts_with(prefix_nibbles)
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,11 +11,18 @@ pub use hex_literal::hex;
 use rand::{rngs::SmallRng, Rng as _, SeedableRng as _};
 
 /// Search for a vanity address with the specified Safe parameters and prefix.
-pub fn search(safe: &mut Safe, prefix: &[u8]) {
+pub fn search(safe: &mut Safe, prefix: &[u8], is_odd_length: bool) {
     let mut rng = SmallRng::from_entropy();
-    while !starts_with_nibbles(&safe.creation_address().0[..], prefix) {
-        safe.update_salt_nonce(|n| rng.fill(n));
+    if is_odd_length {
+        while !starts_with_nibbles(&safe.creation_address().0[..], prefix) {
+            safe.update_salt_nonce(|n| rng.fill(n));
+        }
+    } else {
+        while !safe.creation_address().0.starts_with(prefix) {
+            safe.update_salt_nonce(|n| rng.fill(n));
+        }
     }
+    
 }
 
 fn starts_with_nibbles(data: &[u8], prefix_nibbles: &[u8]) -> bool {

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -67,7 +67,7 @@ fn inner(safe: JsValue, prefix: &str) -> Result<JsValue, Box<dyn Error>> {
     let prefix = hex_decode(prefix)?;
 
     let mut safe = Safe::new(contracts, owners, threshold);
-    deadbeef_core::search(&mut safe, &prefix);
+    deadbeef_core::search(&mut safe, &prefix, false);
 
     let transaction = safe.transaction();
 


### PR DESCRIPTION
allows for odd length prefixes.

still uses efficient logic for even length prefixes, uses less efficient logic for odd length prefixes.

disclaimer: I barely know rust