### PR TITLE
Add Benchmarking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,10 +139,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
-name = "crunchy"
-version = "0.2.3"
+name = "cpufeatures"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "deadbeef"
@@ -160,7 +182,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "rand",
- "tiny-keccak",
+ "sha3",
 ]
 
 [[package]]
@@ -174,6 +196,16 @@ dependencies = [
  "serde-wasm-bindgen",
  "wasm-bindgen",
  "wee_alloc",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -209,6 +241,16 @@ checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -263,6 +305,15 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -425,6 +476,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,13 +513,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-keccak"
-version = "2.0.2"
+name = "typenum"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
-]
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-ident"
@@ -471,6 +529,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/bench/benches/deadbeef.rs
+++ b/bench/benches/deadbeef.rs
@@ -1,8 +1,52 @@
+use deadbeef_core::{address, config, hex, Configuration, Safe};
+
 fn main() {
     divan::main();
 }
 
+fn safe() -> Safe {
+    Safe::new(Configuration {
+        proxy: config::Proxy {
+            factory: address!(nz "fafafafafafafafafafafafafafafafafafafafa"),
+            init_code: hex!(
+                "c0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0de
+                 c0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0de
+                 c0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0de
+                 c0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0de
+                 c0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0de
+                 c0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0de
+                 c0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0de
+                 c0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0de
+                 c0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0de
+                 c0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0de
+                 c0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0de
+                 c0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0de
+                 c0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0dec0de"
+            )
+            .to_vec(),
+            singleton: address!(nz "5afe5afe5afe5afe5afe5afe5afe5afe5afe5afe"),
+        },
+        account: config::Account {
+            owners: vec![address!(nz "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")],
+            threshold: 1,
+            setup: Some(config::SafeToL2Setup {
+                address: address!(nz "5e795e795e795e795e795e795e795e795e795e79"),
+                l2_singleton: address!(nz "5afe125afe125afe125afe125afe125afe125afe"),
+            }),
+            fallback_handler: Some(address!(nz "fa11baccfa11baccfa11baccfa11baccfa11bacc")),
+            identifier: None,
+        },
+    })
+}
+
 #[divan::bench]
-fn foo() -> i32 {
-    divan::black_box(1) + divan::black_box(2)
+fn check(bencher: divan::Bencher) {
+    let mut safe = safe();
+    let prefix = hex!("deadbeef");
+
+    bencher.bench_local(move || {
+        deadbeef_core::search_iter(&mut safe, &divan::black_box(prefix), |n| {
+            n.copy_from_slice(&divan::black_box([0xee; 32]));
+        });
+    });
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,4 +9,4 @@ license = "GPL-3.0-or-later"
 hex = "0.4"
 hex-literal = "1"
 rand = { version = "0.9", features = ["small_rng"] }
-tiny-keccak = { version = "2", features = ["keccak"] }
+sha3 = "0.10"

--- a/core/src/address.rs
+++ b/core/src/address.rs
@@ -1,11 +1,10 @@
+use crate::keccak;
 use hex::FromHexError;
 use std::{
     error::Error,
     fmt::{self, Debug, Display, Formatter},
     str::{self, FromStr},
 };
-
-use crate::keccak;
 
 /// An Ethereum public address.
 #[derive(Copy, Clone, Default, Eq, PartialEq)]

--- a/core/src/address.rs
+++ b/core/src/address.rs
@@ -4,7 +4,8 @@ use std::{
     fmt::{self, Debug, Display, Formatter},
     str::{self, FromStr},
 };
-use tiny_keccak::{Hasher as _, Keccak};
+
+use crate::keccak;
 
 /// An Ethereum public address.
 #[derive(Copy, Clone, Default, Eq, PartialEq)]
@@ -51,14 +52,7 @@ impl Display for Address {
         let addr = &mut buf[2..];
         hex::encode_to_slice(self.0.as_slice(), addr).expect("error decoding hex");
 
-        let digest = {
-            let mut output = [0_u8; 32];
-            let mut hasher = Keccak::v256();
-            hasher.update(addr);
-            hasher.finalize(&mut output);
-            output
-        };
-
+        let digest = keccak::v256(addr);
         for i in 0..addr.len() {
             let byte = digest[i / 2];
             let nibble = 0xf & if i % 2 == 0 { byte >> 4 } else { byte };

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -1,6 +1,8 @@
-use crate::address::{Address, NonZeroAddress};
+use crate::{
+    address::{Address, NonZeroAddress},
+    keccak,
+};
 use hex_literal::hex;
-use tiny_keccak::{Hasher as _, Keccak};
 
 /// The Safe smart account creation configuration.
 #[derive(Clone)]
@@ -25,12 +27,7 @@ pub struct Proxy {
 impl Proxy {
     /// Returns the proxy init code digest.
     pub fn init_code_hash(&self) -> [u8; 32] {
-        let mut output = [0_u8; 32];
-        let mut hasher = Keccak::v256();
-        hasher.update(&self.init_code);
-        hasher.update(&abi::addr(self.singleton.get()));
-        hasher.finalize(&mut output);
-        output
+        keccak::v256_chunked(&[&self.init_code, &abi::addr(self.singleton.get())])
     }
 
     /// Returns the calldata for the `createProxyWithNonce` call on the proxy

--- a/core/src/create2.rs
+++ b/core/src/create2.rs
@@ -1,7 +1,6 @@
 //! Module implementing `CREATE2` deterministic address computation logic.
 
-use crate::address::Address;
-use tiny_keccak::{Hasher as _, Keccak};
+use crate::{address::Address, keccak};
 
 /// `CREATE2` parameters.
 #[derive(Clone, Debug)]
@@ -34,11 +33,8 @@ impl Create2 {
 
     /// Returns the deterministic address for the `CREATE2` parameters.
     pub fn creation_address(&self) -> Address {
-        let mut buffer = [0_u8; 32];
-        let mut hasher = Keccak::v256();
-        hasher.update(&self.0);
-        hasher.finalize(&mut buffer);
-        Address(unsafe { *buffer.get_unchecked(12..32).as_ptr().cast() })
+        let digest = keccak::v256(&self.0);
+        Address(unsafe { *digest.get_unchecked(12..32).as_ptr().cast() })
     }
 }
 

--- a/core/src/keccak.rs
+++ b/core/src/keccak.rs
@@ -1,0 +1,22 @@
+use sha3::{Digest as _, Keccak256};
+
+/// Compute the Keccak-256 hash of the input bytes.
+#[inline]
+pub fn v256(bytes: &[u8]) -> [u8; 32] {
+    let mut output = [0u8; 32];
+    let mut hasher = Keccak256::new();
+    hasher.update(bytes);
+    hasher.finalize_into((&mut output).into());
+    output
+}
+
+/// Compute the Keccak-256 hash of the input byte chunks.
+pub fn v256_chunked(chunks: &[&[u8]]) -> [u8; 32] {
+    let mut output = [0u8; 32];
+    let mut hasher = Keccak256::new();
+    for chunk in chunks {
+        hasher.update(chunk);
+    }
+    hasher.finalize_into((&mut output).into());
+    output
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -2,6 +2,7 @@
 mod address;
 pub mod config;
 mod create2;
+mod keccak;
 mod safe;
 
 pub use self::{
@@ -15,7 +16,14 @@ use rand::{rngs::SmallRng, Rng as _, SeedableRng as _};
 /// Search for a vanity address with the specified Safe parameters and prefix.
 pub fn search(safe: &mut Safe, prefix: &[u8]) {
     let mut rng = SmallRng::from_os_rng();
-    while !safe.creation_address().0.starts_with(prefix) {
-        safe.update_salt_nonce(|n| rng.fill(n));
-    }
+    while !search_iter(safe, prefix, |n| rng.fill(n)) {}
+}
+
+/// Run a single iteration of the vanity address search.
+///
+/// This function is publically exposed to facilitate benchmarking.
+#[doc(hidden)]
+pub fn search_iter(safe: &mut Safe, prefix: &[u8], update: impl FnOnce(&mut [u8; 32])) -> bool {
+    safe.update_salt_nonce(update);
+    safe.creation_address().0.starts_with(prefix)
 }


### PR DESCRIPTION
We now benchmark the iteration loop. As a first small bonus, we change the Keccak-256 implementation we use for a small speed-up (like 1%-2%, so nothing meaningful). This allows us to refactor our code so that swapping out Keccak implementations is very straight forward.