### PR TITLE
feat(cli): add gpu safe address mining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +68,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bit-set"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+
+[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,10 +119,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "cfg-if"
@@ -84,6 +164,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -127,6 +213,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +245,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,10 +264,14 @@ dependencies = [
 name = "deadbeef"
 version = "0.1.1"
 dependencies = [
+ "bytemuck",
  "clap",
  "deadbeef-core",
  "hex",
  "num_cpus",
+ "pollster",
+ "rand",
+ "wgpu",
 ]
 
 [[package]]
@@ -209,6 +316,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
 name = "divan"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +351,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +382,42 @@ checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -268,6 +445,110 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
+name = "glow"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
+ "log",
+ "presser",
+ "thiserror",
+ "windows",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
+dependencies = [
+ "bitflags",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,17 +573,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 
 [[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
-name = "js-sys"
-version = "0.3.77"
+name = "jni-sys"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
 dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+dependencies = [
+ "cfg-if 1.0.0",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -317,10 +644,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.171"
+name = "khronos-egl"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if 1.0.0",
+ "windows-link",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -329,16 +689,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
-name = "log"
-version = "0.4.27"
+name = "litrs"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memory_units"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
+
+[[package]]
+name = "naga"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bitflags",
+ "cfg-if 1.0.0",
+ "cfg_aliases",
+ "codespan-reporting",
+ "half",
+ "hashbrown 0.16.1",
+ "hexf-parse",
+ "indexmap",
+ "libm",
+ "log",
+ "num-traits",
+ "once_cell",
+ "rustc-hash",
+ "spirv",
+ "thiserror",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys 0.3.1",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
 
 [[package]]
 name = "num_cpus"
@@ -351,10 +771,137 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -366,6 +913,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +926,12 @@ checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
 
 [[package]]
 name = "quote"
@@ -420,10 +979,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
@@ -443,6 +1047,12 @@ name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -486,6 +1096,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,6 +1149,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +1165,26 @@ checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -523,6 +1198,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "utf8parse"
@@ -547,35 +1228,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.100"
+name = "wasm-bindgen-futures"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -583,24 +1261,46 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -613,6 +1313,174 @@ dependencies = [
  "libc",
  "memory_units",
  "winapi",
+]
+
+[[package]]
+name = "wgpu"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "bytemuck",
+ "cfg-if 1.0.0",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02da3ad1b568337f25513b317870960ef87073ea0945502e44b864b67a8c77b7"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "bytemuck",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "log",
+ "naga",
+ "once_cell",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash",
+ "smallvec",
+ "thiserror",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-windows-linux-android",
+ "wgpu-hal",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e51b5447e144b3dbba4feb01f80f4fa21696fa0cd99afb2c3df1affd6fdb28"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3487cd6293a963bc5c0c0396f6a2192043c50003c07f4efdccbad3d90ec9d819"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb01076d0aa08b0ba9bd741e178b5cc440f5abe99d9581323a4c8b5d1a1916"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f8e1a9e7a8512f276f7c62e018c7fa8d60954303fed2e5750114332049193f"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
+ "bitflags",
+ "block2",
+ "bytemuck",
+ "cfg-if 1.0.0",
+ "cfg_aliases",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading",
+ "log",
+ "naga",
+ "ndk-sys",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
+ "objc2-quartz-core",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "raw-window-metal",
+ "renderdoc-sys",
+ "smallvec",
+ "thiserror",
+ "wasm-bindgen",
+ "wayland-sys",
+ "web-sys",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+ "windows",
+ "windows-core",
+ "windows-result",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
+dependencies = [
+ "naga",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
+dependencies = [
+ "bitflags",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "raw-window-handle",
+ "web-sys",
 ]
 
 [[package]]
@@ -632,10 +1500,120 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -660,6 +1638,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -720,19 +1707,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.8.24"
+name = "xml-rs"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -55,6 +55,156 @@ Note that the owner signature threshold defaults to 1 but can optionally be spec
 deadbeef ... --threshold 2 ...
 ```
 
+## GPU Mining
+
+GPU mining is opt-in.
+
+### Vocabulary
+
+A handful of terms appear throughout this section and the GPU source files. Defining them up front keeps the rest of the section short:
+
+- **wgpu** is the Rust binding for the WebGPU compute API. It lets one shader (a small program the GPU runs in parallel for every input it is given) run on Apple, NVIDIA, AMD, and Intel GPUs through whichever native driver is available.
+- **Metal** (Apple), **Vulkan** (Linux/Windows on most GPUs), **DX12** (Windows), and **GL** (a fallback path) are the native driver choices wgpu can pick.
+- **WSLg** is Microsoft's GPU bridge for the Windows Subsystem for Linux. **Mesa** is the open-source graphics stack that ships with most Linux distros, and **llvmpipe** is its software-only fallback — do not use it for mining, it runs on the CPU.
+- A **dispatch** is one job the CLI hands the GPU. A **workgroup** is a tile of 256 shader invocations the GPU schedules together; a single **invocation** is one independent run of the shader on one candidate salt nonce.
+- **Readback** means copying a buffer's bytes from the GPU back to the CPU. The miner reads back one tiny 36-byte result struct per dispatch, but the readback is synchronous, so we want each dispatch large enough that the readback is not the bottleneck.
+- **Maddr/s** is "millions of candidate addresses per second."
+
+### Usage
+
+List available adapters:
+
+```sh
+deadbeef --list-gpus
+```
+
+The adapter list includes the device type, plus driver details when wgpu reports
+them. If wgpu reports an adapter as `Cpu / Software Rendering`, the miner will
+not select it by default.
+
+Mine with the first available GPU adapter:
+
+```sh
+deadbeef ... --gpu --prefix 0x00
+```
+
+Select an adapter and backend explicitly:
+
+```sh
+deadbeef ... --gpu --gpu-adapter 0 --gpu-backend metal
+deadbeef ... --gpu --gpu-adapter 0 --gpu-backend vulkan
+deadbeef ... --gpu --gpu-adapter 0 --gpu-backend dx12
+deadbeef ... --gpu --gpu-adapter 0 --gpu-backend gl
+```
+
+Use `metal` for Apple GPUs, `vulkan` for NVIDIA on Linux, and `dx12` or `vulkan` for NVIDIA on Windows.
+On WSLg, Vulkan may only expose Mesa `llvmpipe`; if so, use Mesa's D3D12-backed GL path:
+
+```sh
+GALLIUM_DRIVER=d3d12 MESA_D3D12_DEFAULT_ADAPTER_NAME=NVIDIA \
+  deadbeef ... --gpu --gpu-backend gl
+```
+
+`gl` is a fallback backend. In the current CLI implementation, a GL mining run exits without tearing down the GL miner before process exit.
+
+`--gpu-batch-size` requests how many salt nonces are scanned per dispatch.
+The miner rounds that request up to a whole workgroup and clamps very small or very large values to the supported range.
+The default is `8 × 65,535 × 256 = 134,215,680` candidates per dispatch: WebGPU caps each dispatch dimension at 65,535 workgroups, each workgroup runs 256 invocations, and the host stacks 8 such rows to reduce readback overhead while staying backend-neutral.
+
+How to think about the trade-off: each dispatch ends with a synchronous readback of one tiny result struct, which costs a fixed amount of time regardless of batch size. A larger batch amortises that fixed cost over more candidate addresses, so throughput climbs as the batch grows. The catch is that a larger batch also takes longer to complete, so a slow GPU spends more wall time per dispatch and the miner reports progress less often. Pick a value that fills your GPU but still finishes a dispatch in a few seconds. On high-throughput GPUs, larger explicit batch-size requests can stack more rows and reduce readback overhead further; on slower GPUs, the default is intentionally conservative.
+
+GPU mining prints periodic progress to stderr while it runs; `--quiet` disables those progress messages.
+
+### Reference Benchmarks
+
+These numbers are a point-in-time reference, not a guaranteed result. GPU and CPU throughput can change with power state, thermal state, other GPU work, compiler versions, and batch size.
+The CPU benchmark below measures one CPU core in the core mining loop. The normal CLI CPU miner uses multiple threads by default, so it can be faster than the single-core number shown here.
+The benchmark results below were recorded on May 3, 2026 against branch commit `da8cf78`.
+
+Each dispatch row covers `65,535 × 256 = 16,776,960` candidates, so larger `--gpu-batch-size` values use more rows: a single-row dispatch covers about 16.8 million candidates, the default eight-row dispatch covers about 134.2 million, and a 32-row dispatch covers about 536.9 million.
+
+The `DEADBEEF_GPU_BENCH_*` environment variables in the commands below are read only by the ignored benchmark test, not by the normal `deadbeef --gpu` CLI; setting them on a regular mining run has no effect.
+
+MacBook Pro environment:
+
+- MacBook Pro `Mac15,10`
+- Apple M3 Max, 14-core CPU (10 performance, 4 efficiency)
+- Apple M3 Max GPU, 30 cores, Metal backend
+- 36 GB memory
+- macOS 26.4.1
+- Rust 1.95.0, Cargo 1.95.0
+
+MacBook Pro benchmark commands:
+
+```sh
+cargo bench -p deadbeef-bench
+```
+
+```sh
+DEADBEEF_GPU_BENCH_BATCH_SIZE=134215680 \
+cargo test --release -p deadbeef gpu_benchmark_fixed_batches -- --ignored --nocapture
+```
+
+| Miner | Result |
+| --- | --- |
+| CPU, single-thread core loop | 297 ns/address mean, about 3.37 Maddr/s |
+| GPU, Metal, default 8-row dispatch batch | 17,179,607,040 candidates in 66.978 s, about 256.50 Maddr/s |
+
+On this machine, the GPU benchmark is about 76x faster than one CPU core in the core mining loop.
+
+WSL2 desktop environment:
+
+- Ubuntu 24.04.4 LTS on WSL 2.4.12.0, WSLg 1.0.65
+- Windows build 10.0.26200.8246
+- AMD Ryzen 9 7900 12-core CPU, 24 logical CPUs
+- NVIDIA GeForce RTX 5090, 32 GB VRAM, driver 596.21
+- WSLg/Mesa D3D12 GL backend, selected with `GALLIUM_DRIVER=d3d12 MESA_D3D12_DEFAULT_ADAPTER_NAME=NVIDIA --gpu-backend gl`
+- Rust 1.95.0, Cargo 1.95.0
+
+WSL2 benchmark commands:
+
+```sh
+cargo bench -p deadbeef-bench
+```
+
+```sh
+GALLIUM_DRIVER=d3d12 \
+MESA_D3D12_DEFAULT_ADAPTER_NAME=NVIDIA \
+DEADBEEF_GPU_BENCH_BACKEND=gl \
+DEADBEEF_GPU_BENCH_BATCH_SIZE=16776960 \
+cargo test --release -p deadbeef gpu_benchmark_fixed_batches -- --ignored --nocapture
+```
+
+```sh
+GALLIUM_DRIVER=d3d12 \
+MESA_D3D12_DEFAULT_ADAPTER_NAME=NVIDIA \
+DEADBEEF_GPU_BENCH_BACKEND=gl \
+DEADBEEF_GPU_BENCH_BATCH_SIZE=134215680 \
+cargo test --release -p deadbeef gpu_benchmark_fixed_batches -- --ignored --nocapture
+```
+
+```sh
+GALLIUM_DRIVER=d3d12 \
+MESA_D3D12_DEFAULT_ADAPTER_NAME=NVIDIA \
+DEADBEEF_GPU_BENCH_BACKEND=gl \
+DEADBEEF_GPU_BENCH_BATCH_SIZE=536862720 \
+cargo test --release -p deadbeef gpu_benchmark_fixed_batches -- --ignored --nocapture
+```
+
+| Miner | Result |
+| --- | --- |
+| CPU, single-thread core loop | 573.3 ns/address mean, about 1.74 Maddr/s |
+| GPU, GL over D3D12, single-row dispatch batch | 2,147,450,880 candidates in 1.112 s, about 1,930.93 Maddr/s |
+| GPU, GL over D3D12, default 8-row dispatch batch | 17,179,607,040 candidates in 8.159 s, about 2,105.58 Maddr/s |
+| GPU, GL over D3D12, tuned 32-row dispatch batch | 68,718,428,160 candidates in 30.886 s, about 2,224.92 Maddr/s |
+
+On this machine, the fastest GPU benchmark above is about 1,280x faster than one CPU core in the core mining loop.
+
+### GPU Implementation Notes
+
+The GPU miner keeps Safe construction and final verification on the CPU.
+The shader only scans candidate salt nonces and returns a matching nonce for the CPU to re-check.
+
 For using Safe deployments on different chains can also be used:
 
 ```sh

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,7 +6,11 @@ publish = false
 license = "GPL-3.0-or-later"
 
 [dependencies]
+bytemuck = { version = "1", features = ["derive"] }
 clap = { version = "4", features = ["derive"] }
 deadbeef-core = { version = "0.1.0", path = "../core" }
 hex = "0.4"
 num_cpus = "1"
+pollster = "0.4"
+rand = "0.9"
+wgpu = "29"

--- a/cli/src/gpu.rs
+++ b/cli/src/gpu.rs
@@ -1,0 +1,191 @@
+//! GPU-backed Safe address mining.
+//!
+//! The CPU owns Safe configuration and final verification. The GPU only scans
+//! candidate salt nonces and returns a matching nonce for the CPU to re-check.
+//!
+mod adapter;
+mod dispatch;
+mod input;
+mod miner;
+
+#[cfg(test)]
+mod tests;
+
+use self::{
+    adapter::{adapter_description, adapters, NO_ADAPTERS},
+    dispatch::DispatchLayout,
+    input::{pack_words, GpuInput},
+    miner::{Miner, MinerGuard},
+};
+use clap::ValueEnum;
+use deadbeef_core::Safe;
+use rand::Rng as _;
+use std::{
+    error::Error,
+    io,
+    time::{Duration, Instant},
+};
+
+const PROGRESS_INTERVAL: Duration = Duration::from_secs(5);
+
+type Result<T> = std::result::Result<T, Box<dyn Error>>;
+
+pub const DEFAULT_BATCH_SIZE: u32 = dispatch::DEFAULT_BATCH_SIZE;
+
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, ValueEnum)]
+pub enum Backend {
+    #[default]
+    Primary,
+    Metal,
+    Vulkan,
+    Dx12,
+    Gl,
+}
+
+impl Backend {
+    /// Translate the user-facing backend choice into the bitset wgpu expects.
+    pub(super) fn to_wgpu_bitset(self) -> wgpu::Backends {
+        match self {
+            Self::Primary => wgpu::Backends::PRIMARY,
+            Self::Metal => wgpu::Backends::METAL,
+            Self::Vulkan => wgpu::Backends::VULKAN,
+            Self::Dx12 => wgpu::Backends::DX12,
+            Self::Gl => wgpu::Backends::GL,
+        }
+    }
+}
+
+/// Runtime options for GPU mining.
+#[derive(Copy, Clone, Debug)]
+pub struct Options {
+    /// GPU backend to enumerate. `Primary` lets wgpu choose the native backend.
+    pub backend: Backend,
+    /// Adapter index from `--list-gpus`; `None` selects the first adapter.
+    pub adapter: Option<usize>,
+    /// Candidate count per compute dispatch. Rounded to `WORKGROUP_SIZE`.
+    pub batch_size: u32,
+    /// Allow adapters that wgpu reports as CPU/software renderers.
+    pub allow_software_adapter: bool,
+    /// Print progress to stderr between GPU dispatches.
+    pub progress: bool,
+}
+
+struct Progress {
+    start: Instant,
+    next_report: Instant,
+    dispatched: u64,
+}
+
+pub fn list_adapters(backend: Backend) -> Result<()> {
+    let adapters = adapters(backend);
+    if adapters.is_empty() {
+        return Err(err(NO_ADAPTERS));
+    }
+
+    for (index, adapter) in adapters.iter().enumerate() {
+        let info = adapter.get_info();
+        println!("{index}: {}", adapter_description(&info));
+    }
+
+    Ok(())
+}
+
+pub fn search(safe: &mut Safe, prefix: &[u8], options: Options) -> Result<()> {
+    if prefix.len() > 20 {
+        return Err(err("prefix cannot be longer than an Ethereum address"));
+    }
+
+    let context = safe.search_context();
+    let dispatch = DispatchLayout::for_requested_candidates(options.batch_size);
+    let batch_size = dispatch.candidates;
+    let miner = MinerGuard::new(
+        Miner::new(
+            options.backend,
+            options.adapter,
+            options.allow_software_adapter,
+        )?,
+        options.backend,
+    );
+    let mut rng = rand::rng();
+    let mut nonce_prefix = [0_u8; 24];
+    rng.fill(&mut nonce_prefix);
+    let mut counter = 0_u64;
+    let mut progress = options
+        .progress
+        .then(|| Progress::new(prefix.len(), batch_size));
+
+    // Nonce generation is split across CPU and GPU:
+    //
+    //   saltNonce = random_24_byte_prefix || sequential_8_byte_counter
+    //
+    // The CPU chooses the random prefix once per 2^64-counter range, while the
+    // GPU scans the counter range sequentially. This keeps dispatch input small
+    // and avoids per-candidate RNG in the shader.
+    let mut input = GpuInput::for_search(&context, prefix, &nonce_prefix, dispatch);
+
+    loop {
+        // Exhausting one 64-bit counter range is theoretical; if it happens,
+        // re-randomize the nonce prefix instead of repeating the same range.
+        if counter.checked_add(u64::from(batch_size)).is_none() {
+            rng.fill(&mut nonce_prefix);
+            input.nonce_prefix = pack_words(&nonce_prefix);
+            counter = 0;
+        }
+
+        input.set_counter(counter);
+
+        if let Some(nonce) = miner.run_batch(&input, &dispatch)? {
+            let address = context.creation_address(nonce);
+
+            // Fail closed if the untrusted GPU candidate disagrees with the CPU
+            // derivation; continuing would hide a broken shader or driver path.
+            if !address.0.starts_with(prefix) {
+                return Err(err("GPU result did not match the requested prefix"));
+            }
+
+            safe.update_salt_nonce(|n| *n = nonce);
+            return Ok(());
+        }
+
+        if let Some(progress) = &mut progress {
+            progress.record_batch(batch_size);
+        }
+        counter += u64::from(batch_size);
+    }
+}
+
+impl Progress {
+    fn new(prefix_len: usize, batch_size: u32) -> Self {
+        let now = Instant::now();
+        eprintln!(
+            "GPU mining: scanning {prefix_len}-byte prefix with {batch_size} candidates per dispatch"
+        );
+        Self {
+            start: now,
+            next_report: now + PROGRESS_INTERVAL,
+            dispatched: 0,
+        }
+    }
+
+    fn record_batch(&mut self, batch_size: u32) {
+        self.dispatched += u64::from(batch_size);
+
+        let now = Instant::now();
+        if now < self.next_report {
+            return;
+        }
+
+        let elapsed = now.duration_since(self.start).as_secs_f64();
+        let rate = self.dispatched as f64 / elapsed / 1_000_000.0;
+        eprintln!(
+            "GPU mining: dispatched {:.2}M candidates in {:.1}s ({rate:.2} Maddr/s)",
+            self.dispatched as f64 / 1_000_000.0,
+            elapsed,
+        );
+        self.next_report = now + PROGRESS_INTERVAL;
+    }
+}
+
+fn err(message: impl Into<String>) -> Box<dyn Error> {
+    Box::new(io::Error::other(message.into()))
+}

--- a/cli/src/gpu.wgsl
+++ b/cli/src/gpu.wgsl
@@ -1,0 +1,427 @@
+const WORKGROUP_SIZE: u32 = 256u;
+
+// Keep these structs in the same field order as `GpuInput` and `GpuResult` in
+// `gpu.rs`. The Rust tests compare both sides field-by-field.
+struct Input {
+  // Fixed for a Safe configuration:
+  // - initializer_hash = keccak256(initializer)
+  // - factory = SafeProxyFactory address, 20 bytes packed into 5 words
+  // - init_code_hash = keccak256(proxy init code || singleton ABI word)
+  initializer_hash: array<u32, 8>,
+  factory: array<u32, 5>,
+  init_code_hash: array<u32, 8>,
+  // Prefix bytes packed into 5 words. `prefix_len` tells us how many bytes are
+  // significant, so the unused high bytes stay zero.
+  prefix: array<u32, 5>,
+  // First 24 bytes of the candidate salt nonce. The final 8 bytes are the
+  // counter in big-endian byte order: high bytes first, then low bytes. This
+  // struct stores the numeric halves as plain u32 values: `counter_low` holds
+  // the lower 32 bits, and `counter_high` holds the upper 32 bits.
+  nonce_prefix: array<u32, 6>,
+  prefix_len: u32,
+  // Candidate count in one dispatch row. The host uses this to support
+  // rectangular dispatches without adding a per-invocation bounds check.
+  candidates_per_row: u32,
+  counter_low: u32,
+  counter_high: u32,
+}
+
+struct ResultBuffer {
+  // Claimed with an atomic exchange so only one invocation writes a result.
+  // `atomic<u32>` has the same 4-byte size and alignment as a plain `u32`;
+  // after the GPU finishes, Rust reads this slot as `GpuResult.found`.
+  // The CPU re-derives the address from `nonce` before accepting it.
+  found: atomic<u32>,
+  nonce: array<u32, 8>,
+}
+
+// Keccak-f[1600] stores its 1600-bit state as 25 64-bit words, traditionally
+// called lanes. These are Keccak state lanes, not GPU execution lanes. WGSL
+// does not expose portable u64 arithmetic across all target backends we care
+// about, so each Keccak lane is represented as two u32 halves.
+struct U64 {
+  lo: u32,
+  hi: u32,
+}
+
+@group(0) @binding(0) var<storage, read> input: Input;
+@group(0) @binding(1) var<storage, read_write> result: ResultBuffer;
+
+// Basic bitwise operations on emulated 64-bit Keccak lanes.
+fn xor64(a: U64, b: U64) -> U64 {
+  return U64(a.lo ^ b.lo, a.hi ^ b.hi);
+}
+
+fn and64(a: U64, b: U64) -> U64 {
+  return U64(a.lo & b.lo, a.hi & b.hi);
+}
+
+fn not64(a: U64) -> U64 {
+  return U64(~a.lo, ~a.hi);
+}
+
+// Rotate an emulated 64-bit lane left by Keccak's fixed rotation offsets.
+fn rotl64(a: U64, n: u32) -> U64 {
+  if (n == 0u) {
+    return a;
+  }
+  if (n < 32u) {
+    return U64((a.lo << n) | (a.hi >> (32u - n)), (a.hi << n) | (a.lo >> (32u - n)));
+  }
+  if (n == 32u) {
+    return U64(a.hi, a.lo);
+  }
+
+  let m = n - 32u;
+  return U64((a.hi << m) | (a.lo >> (32u - m)), (a.lo << m) | (a.hi >> (32u - m)));
+}
+
+// Keccak round constants RC[0..24] for the iota step (FIPS 202 sec. 3.2.5,
+// table at the end of the section). These values are identical between
+// original Keccak and the SHA-3 family; only the padding rule differs.
+//
+// Spec PDF: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf
+//
+// Each constant is written as two u32 halves in little-endian byte order to
+// match the `U64` lane representation above.
+const ROUND_CONSTANTS: array<U64, 24> = array<U64, 24>(
+  U64(0x00000001u, 0x00000000u),
+  U64(0x00008082u, 0x00000000u),
+  U64(0x0000808au, 0x80000000u),
+  U64(0x80008000u, 0x80000000u),
+  U64(0x0000808bu, 0x00000000u),
+  U64(0x80000001u, 0x00000000u),
+  U64(0x80008081u, 0x80000000u),
+  U64(0x00008009u, 0x80000000u),
+  U64(0x0000008au, 0x00000000u),
+  U64(0x00000088u, 0x00000000u),
+  U64(0x80008009u, 0x00000000u),
+  U64(0x8000000au, 0x00000000u),
+  U64(0x8000808bu, 0x00000000u),
+  U64(0x0000008bu, 0x80000000u),
+  U64(0x00008089u, 0x80000000u),
+  U64(0x00008003u, 0x80000000u),
+  U64(0x00008002u, 0x80000000u),
+  U64(0x00000080u, 0x80000000u),
+  U64(0x0000800au, 0x00000000u),
+  U64(0x8000000au, 0x80000000u),
+  U64(0x80008081u, 0x80000000u),
+  U64(0x00008080u, 0x80000000u),
+  U64(0x80000001u, 0x00000000u),
+  U64(0x80008008u, 0x80000000u),
+);
+
+// Reverse byte order for one 32-bit half of the counter. The input buffer keeps
+// the counter as numeric low/high words; this conversion happens only at the
+// boundary where that number becomes bytes in the final saltNonce.
+fn bswap32(x: u32) -> u32 {
+  return ((x & 0x000000ffu) << 24u)
+    | ((x & 0x0000ff00u) << 8u)
+    | ((x & 0x00ff0000u) >> 8u)
+    | ((x & 0xff000000u) >> 24u);
+}
+
+fn shift_join(a: u32, b: u32) -> u32 {
+  // CREATE2's 85-byte preimage starts with one leading 0xff byte, so every
+  // following field is shifted by one byte. This joins the last byte of `a`
+  // with the first three bytes of `b`.
+  //
+  // Example with little-endian words:
+  //   a = 0xDDCCBBAA, bytes AA BB CC DD
+  //   b = 0x44332211, bytes 11 22 33 44
+  //   shift_join(a, b) returns 0x332211DD, bytes DD 11 22 33
+  return (a >> 24u) | ((b & 0x00ffffffu) << 8u);
+}
+
+// Low 32 bits of this invocation's 64-bit counter value.
+fn counter_low(offset: u32) -> u32 {
+  return input.counter_low + offset;
+}
+
+// High 32 bits of this invocation's 64-bit counter value, including carry from
+// adding the invocation offset to the low half.
+fn counter_high(offset: u32) -> u32 {
+  let low = counter_low(offset);
+  let carry = select(0u, 1u, low < input.counter_low);
+  return input.counter_high + carry;
+}
+
+fn keccakf(state: ptr<function, array<U64, 25>>) {
+  // Keccak-f[1600] permutation, 24 rounds. Each round applies five named steps
+  // in fixed order: theta -> rho -> pi -> chi -> iota. This implementation
+  // unrolls every step inside the round body because that was materially
+  // faster than dynamic lane-index loops on Metal; the outer round loop is
+  // kept to keep shader code size and register pressure bounded.
+  //
+  // Spec: FIPS 202 sec. 3.2 (https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf).
+  //
+  // WGSL note: `state` is a pointer to a function-local array, so each lane
+  // access uses `(*state)[i]` rather than `state[i]`.
+  for (var round = 0u; round < 24u; round = round + 1u) {
+    var b: array<U64, 25>;
+
+    // theta: mix each column's parity into every lane in that column.
+    let c0 = xor64(xor64(xor64(xor64((*state)[0], (*state)[5]), (*state)[10]), (*state)[15]), (*state)[20]);
+    let c1 = xor64(xor64(xor64(xor64((*state)[1], (*state)[6]), (*state)[11]), (*state)[16]), (*state)[21]);
+    let c2 = xor64(xor64(xor64(xor64((*state)[2], (*state)[7]), (*state)[12]), (*state)[17]), (*state)[22]);
+    let c3 = xor64(xor64(xor64(xor64((*state)[3], (*state)[8]), (*state)[13]), (*state)[18]), (*state)[23]);
+    let c4 = xor64(xor64(xor64(xor64((*state)[4], (*state)[9]), (*state)[14]), (*state)[19]), (*state)[24]);
+    let d0 = xor64(c4, rotl64(c1, 1u));
+    let d1 = xor64(c0, rotl64(c2, 1u));
+    let d2 = xor64(c1, rotl64(c3, 1u));
+    let d3 = xor64(c2, rotl64(c4, 1u));
+    let d4 = xor64(c3, rotl64(c0, 1u));
+
+    (*state)[0] = xor64((*state)[0], d0);
+    (*state)[5] = xor64((*state)[5], d0);
+    (*state)[10] = xor64((*state)[10], d0);
+    (*state)[15] = xor64((*state)[15], d0);
+    (*state)[20] = xor64((*state)[20], d0);
+    (*state)[1] = xor64((*state)[1], d1);
+    (*state)[6] = xor64((*state)[6], d1);
+    (*state)[11] = xor64((*state)[11], d1);
+    (*state)[16] = xor64((*state)[16], d1);
+    (*state)[21] = xor64((*state)[21], d1);
+    (*state)[2] = xor64((*state)[2], d2);
+    (*state)[7] = xor64((*state)[7], d2);
+    (*state)[12] = xor64((*state)[12], d2);
+    (*state)[17] = xor64((*state)[17], d2);
+    (*state)[22] = xor64((*state)[22], d2);
+    (*state)[3] = xor64((*state)[3], d3);
+    (*state)[8] = xor64((*state)[8], d3);
+    (*state)[13] = xor64((*state)[13], d3);
+    (*state)[18] = xor64((*state)[18], d3);
+    (*state)[23] = xor64((*state)[23], d3);
+    (*state)[4] = xor64((*state)[4], d4);
+    (*state)[9] = xor64((*state)[9], d4);
+    (*state)[14] = xor64((*state)[14], d4);
+    (*state)[19] = xor64((*state)[19], d4);
+    (*state)[24] = xor64((*state)[24], d4);
+
+    // rho + pi: rotate each lane left by a fixed offset (rho) and move it to
+    // a new position in the state (pi). Both tables are from FIPS 202 sec.
+    // 3.2.2/3.2.3; rotation offsets like 1, 62, 28, 27, ... are the rho
+    // offset table, and the b[10]/b[20]/... destinations are the pi
+    // permutation. The b array is the new state being assembled.
+    b[0] = (*state)[0];
+    b[10] = rotl64((*state)[1], 1u);
+    b[20] = rotl64((*state)[2], 62u);
+    b[5] = rotl64((*state)[3], 28u);
+    b[15] = rotl64((*state)[4], 27u);
+    b[16] = rotl64((*state)[5], 36u);
+    b[1] = rotl64((*state)[6], 44u);
+    b[11] = rotl64((*state)[7], 6u);
+    b[21] = rotl64((*state)[8], 55u);
+    b[6] = rotl64((*state)[9], 20u);
+    b[7] = rotl64((*state)[10], 3u);
+    b[17] = rotl64((*state)[11], 10u);
+    b[2] = rotl64((*state)[12], 43u);
+    b[12] = rotl64((*state)[13], 25u);
+    b[22] = rotl64((*state)[14], 39u);
+    b[23] = rotl64((*state)[15], 41u);
+    b[8] = rotl64((*state)[16], 45u);
+    b[18] = rotl64((*state)[17], 15u);
+    b[3] = rotl64((*state)[18], 21u);
+    b[13] = rotl64((*state)[19], 8u);
+    b[14] = rotl64((*state)[20], 18u);
+    b[24] = rotl64((*state)[21], 2u);
+    b[9] = rotl64((*state)[22], 61u);
+    b[19] = rotl64((*state)[23], 56u);
+    b[4] = rotl64((*state)[24], 14u);
+
+    // chi: nonlinear row mix. For each row of five lanes, replace each lane
+    // with `lane XOR (NOT next_lane AND lane_after_that)`. This is the only
+    // nonlinear step in the round (FIPS 202 sec. 3.2.4).
+    (*state)[0] = xor64(b[0], and64(not64(b[1]), b[2]));
+    (*state)[1] = xor64(b[1], and64(not64(b[2]), b[3]));
+    (*state)[2] = xor64(b[2], and64(not64(b[3]), b[4]));
+    (*state)[3] = xor64(b[3], and64(not64(b[4]), b[0]));
+    (*state)[4] = xor64(b[4], and64(not64(b[0]), b[1]));
+    (*state)[5] = xor64(b[5], and64(not64(b[6]), b[7]));
+    (*state)[6] = xor64(b[6], and64(not64(b[7]), b[8]));
+    (*state)[7] = xor64(b[7], and64(not64(b[8]), b[9]));
+    (*state)[8] = xor64(b[8], and64(not64(b[9]), b[5]));
+    (*state)[9] = xor64(b[9], and64(not64(b[5]), b[6]));
+    (*state)[10] = xor64(b[10], and64(not64(b[11]), b[12]));
+    (*state)[11] = xor64(b[11], and64(not64(b[12]), b[13]));
+    (*state)[12] = xor64(b[12], and64(not64(b[13]), b[14]));
+    (*state)[13] = xor64(b[13], and64(not64(b[14]), b[10]));
+    (*state)[14] = xor64(b[14], and64(not64(b[10]), b[11]));
+    (*state)[15] = xor64(b[15], and64(not64(b[16]), b[17]));
+    (*state)[16] = xor64(b[16], and64(not64(b[17]), b[18]));
+    (*state)[17] = xor64(b[17], and64(not64(b[18]), b[19]));
+    (*state)[18] = xor64(b[18], and64(not64(b[19]), b[15]));
+    (*state)[19] = xor64(b[19], and64(not64(b[15]), b[16]));
+    (*state)[20] = xor64(b[20], and64(not64(b[21]), b[22]));
+    (*state)[21] = xor64(b[21], and64(not64(b[22]), b[23]));
+    (*state)[22] = xor64(b[22], and64(not64(b[23]), b[24]));
+    (*state)[23] = xor64(b[23], and64(not64(b[24]), b[20]));
+    (*state)[24] = xor64(b[24], and64(not64(b[20]), b[21]));
+
+    // iota: XOR a per-round constant into lane 0 to break round symmetry.
+    (*state)[0] = xor64((*state)[0], ROUND_CONSTANTS[round]);
+  }
+}
+
+fn keccak_safe_salt(offset: u32) -> array<u32, 8> {
+  var state: array<U64, 25>;
+
+  // SafeProxyFactory does not use the user-provided salt nonce directly. It
+  // first hashes `keccak(initializer) || saltNonce`, then uses that digest as
+  // the CREATE2 salt. This is the Safe-specific step that a generic CREATE2
+  // vanity miner would miss.
+  //
+  // The input is exactly 64 bytes, which fits in one Keccak rate block of
+  // 136 bytes (rate r = 1088 bits for keccak256). Original Keccak (Ethereum's
+  // `keccak256`) uses pad10*1 padding written as bytes: a `0x01` right after
+  // the message and a `0x80` at the last byte of the rate block (here, bytes
+  // 64 and 135). This is *not* SHA-3, which would use `0x06` instead of
+  // `0x01` for domain separation.
+  //
+  // Padding reference: https://keccak.team/keccak_specs_summary.html.
+  //
+  // WGSL gives `state` its zero value before these assignments run. That means
+  // every Keccak lane starts as zero, and the code below writes only the lanes
+  // that hold message bytes or padding bytes.
+  state[0] = U64(input.initializer_hash[0], input.initializer_hash[1]);
+  state[1] = U64(input.initializer_hash[2], input.initializer_hash[3]);
+  state[2] = U64(input.initializer_hash[4], input.initializer_hash[5]);
+  state[3] = U64(input.initializer_hash[6], input.initializer_hash[7]);
+  state[4] = U64(input.nonce_prefix[0], input.nonce_prefix[1]);
+  state[5] = U64(input.nonce_prefix[2], input.nonce_prefix[3]);
+  state[6] = U64(input.nonce_prefix[4], input.nonce_prefix[5]);
+  // state[7] holds preimage bytes 56..63 - the 8-byte counter tail of the
+  // saltNonce. Safe expects that tail in big-endian byte order:
+  //
+  //   counter 0x0102030405060708 -> nonce bytes 01 02 03 04 05 06 07 08
+  //
+  // Keccak lanes read each u32 as little-endian bytes. Writing counter_high
+  // directly into lane.lo would produce 04 03 02 01, so each 32-bit half is
+  // byte-swapped before it enters the lane. The high half still lands in lo
+  // because lane.lo covers bytes 56..59; the low half lands in hi because
+  // lane.hi covers bytes 60..63.
+  state[7] = U64(bswap32(counter_high(offset)), bswap32(counter_low(offset)));
+  state[8] = U64(0x00000001u, 0x00000000u);
+  state[16] = U64(0x00000000u, 0x80000000u);
+  keccakf(&state);
+
+  return array<u32, 8>(
+    state[0].lo,
+    state[0].hi,
+    state[1].lo,
+    state[1].hi,
+    state[2].lo,
+    state[2].hi,
+    state[3].lo,
+    state[3].hi,
+  );
+}
+
+fn keccak_create2(safe_salt: array<u32, 8>) -> array<u32, 8> {
+  var state: array<U64, 25>;
+
+  // CREATE2 preimage:
+  //   0xff || factory(20) || safe_salt(32) || init_code_hash(32)
+  //
+  // That is 85 bytes, still one Keccak rate block (136 bytes). Because the
+  // first byte is 0xff, every following component starts at byte offset 1;
+  // `shift_join` assembles those unaligned bytes directly into Keccak lanes.
+  //
+  // Padding follows the same original-Keccak rule used in `keccak_safe_salt`:
+  // a `0x01` byte at offset 85 (right after the message) and a `0x80` byte at
+  // offset 135 (last byte of the rate block). See
+  // https://keccak.team/keccak_specs_summary.html.
+  //
+  // WGSL gives `state` its zero value before these assignments run. That means
+  // every Keccak lane starts as zero, and the code below writes only the lanes
+  // that hold message bytes or padding bytes.
+  // state[0]: byte 0 = 0xff (the CREATE2 leading byte), then the low 3 bytes
+  // of factory[0] at offsets 1..3. shift_join handles every later lane, but
+  // this first lane is asymmetric because of that 0xff.
+  state[0] = U64(0x000000ffu | ((input.factory[0] & 0x00ffffffu) << 8u), shift_join(input.factory[0], input.factory[1]));
+  state[1] = U64(shift_join(input.factory[1], input.factory[2]), shift_join(input.factory[2], input.factory[3]));
+  state[2] = U64(shift_join(input.factory[3], input.factory[4]), (input.factory[4] >> 24u) | ((safe_salt[0] & 0x00ffffffu) << 8u));
+  state[3] = U64(shift_join(safe_salt[0], safe_salt[1]), shift_join(safe_salt[1], safe_salt[2]));
+  state[4] = U64(shift_join(safe_salt[2], safe_salt[3]), shift_join(safe_salt[3], safe_salt[4]));
+  state[5] = U64(shift_join(safe_salt[4], safe_salt[5]), shift_join(safe_salt[5], safe_salt[6]));
+  state[6] = U64(shift_join(safe_salt[6], safe_salt[7]), (safe_salt[7] >> 24u) | ((input.init_code_hash[0] & 0x00ffffffu) << 8u));
+  state[7] = U64(shift_join(input.init_code_hash[0], input.init_code_hash[1]), shift_join(input.init_code_hash[1], input.init_code_hash[2]));
+  state[8] = U64(shift_join(input.init_code_hash[2], input.init_code_hash[3]), shift_join(input.init_code_hash[3], input.init_code_hash[4]));
+  state[9] = U64(shift_join(input.init_code_hash[4], input.init_code_hash[5]), shift_join(input.init_code_hash[5], input.init_code_hash[6]));
+  // state[10]: bytes 80..83 are the next 4 bytes of init_code_hash, byte 84 is
+  // its final byte (last byte of the 85-byte preimage), and the | 0x00000100u
+  // places the 0x01 Keccak padding byte at preimage offset 85.
+  state[10] = U64(shift_join(input.init_code_hash[6], input.init_code_hash[7]), (input.init_code_hash[7] >> 24u) | 0x00000100u);
+  state[16] = U64(0x00000000u, 0x80000000u);
+  keccakf(&state);
+
+  return array<u32, 8>(
+    state[0].lo,
+    state[0].hi,
+    state[1].lo,
+    state[1].hi,
+    state[2].lo,
+    state[2].hi,
+    state[3].lo,
+    state[3].hi,
+  );
+}
+
+// Returns a u32 with the low `bytes` bytes set to 0xff and the rest zero. Used
+// to compare a partial trailing word of the prefix against the digest.
+fn prefix_mask(bytes: u32) -> u32 {
+  switch bytes {
+    case 1u: { return 0x000000ffu; }
+    case 2u: { return 0x0000ffffu; }
+    case 3u: { return 0x00ffffffu; }
+    default: { return 0x00000000u; }
+  }
+}
+
+fn matches_prefix(digest: array<u32, 8>) -> bool {
+  // Ethereum addresses are the low 20 bytes of the Keccak digest, i.e.
+  // digest[12..32]. Since `digest` is packed little-endian, that begins at word
+  // index 3. Compare whole words first, then mask the final partial word.
+  let words = input.prefix_len / 4u;
+  for (var i = 0u; i < words; i = i + 1u) {
+    if (digest[i + 3u] != input.prefix[i]) {
+      return false;
+    }
+  }
+
+  let remainder = input.prefix_len & 3u;
+  if (remainder == 0u) {
+    return true;
+  }
+
+  let mask = prefix_mask(remainder);
+  return (digest[words + 3u] & mask) == (input.prefix[words] & mask);
+}
+
+@compute @workgroup_size(WORKGROUP_SIZE)
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+  // WebGPU calls columns x and rows y. The host writes the candidate count per
+  // row here so rectangular dispatches still produce dense candidate offsets
+  // without an `offset >= batch_size` branch.
+  let offset = id.x + id.y * input.candidates_per_row;
+  let safe_salt = keccak_safe_salt(offset);
+  let digest = keccak_create2(safe_salt);
+  if (!matches_prefix(digest)) {
+    return;
+  }
+
+  // Many invocations may match at once. atomicExchange writes 1u into
+  // result.found and returns whatever was there before. Whichever invocation
+  // sees a return value of 0 is the first to claim the slot, so it writes the
+  // nonce. Later claimants see 1 and skip the write.
+  if (atomicExchange(&result.found, 1u) == 0u) {
+    result.nonce[0] = input.nonce_prefix[0];
+    result.nonce[1] = input.nonce_prefix[1];
+    result.nonce[2] = input.nonce_prefix[2];
+    result.nonce[3] = input.nonce_prefix[3];
+    result.nonce[4] = input.nonce_prefix[4];
+    result.nonce[5] = input.nonce_prefix[5];
+    result.nonce[6] = bswap32(counter_high(offset));
+    result.nonce[7] = bswap32(counter_low(offset));
+  }
+}

--- a/cli/src/gpu/adapter.rs
+++ b/cli/src/gpu/adapter.rs
@@ -1,0 +1,83 @@
+use super::{err, Backend, Result};
+
+pub(super) const NO_ADAPTERS: &str = "no matching GPU adapters found";
+const NO_HARDWARE_ADAPTERS: &str = "only software-rendered GPU adapters were found";
+
+pub(super) fn adapters(backend: Backend) -> Vec<wgpu::Adapter> {
+    let backends = backend.to_wgpu_bitset();
+    let mut descriptor = wgpu::InstanceDescriptor::new_without_display_handle();
+    descriptor.backends = backends;
+    let instance = wgpu::Instance::new(descriptor);
+    pollster::block_on(instance.enumerate_adapters(backends))
+}
+
+pub(super) fn select_adapter(
+    backend: Backend,
+    adapter_index: Option<usize>,
+    allow_software_adapter: bool,
+) -> Result<wgpu::Adapter> {
+    let adapters = adapters(backend);
+    if adapters.is_empty() {
+        return Err(err(NO_ADAPTERS));
+    }
+
+    if let Some(index) = adapter_index {
+        let adapter = adapters
+            .into_iter()
+            .nth(index)
+            .ok_or_else(|| err(format!("GPU adapter {index} was not found")))?;
+        ensure_adapter_can_mine(&adapter, allow_software_adapter)?;
+        return Ok(adapter);
+    }
+
+    adapters
+        .into_iter()
+        .find(|adapter| adapter_can_mine(adapter, allow_software_adapter))
+        .ok_or_else(|| {
+            err(format!(
+                "{NO_HARDWARE_ADAPTERS}; use CPU mining or pass --allow-software-gpu for diagnostics"
+            ))
+        })
+}
+
+fn ensure_adapter_can_mine(adapter: &wgpu::Adapter, allow_software_adapter: bool) -> Result<()> {
+    if adapter_can_mine(adapter, allow_software_adapter) {
+        return Ok(());
+    }
+
+    let info = adapter.get_info();
+    Err(err(format!(
+        "GPU adapter is a software renderer, not a hardware GPU: {}. Use CPU mining or pass \
+         --allow-software-gpu for diagnostics",
+        adapter_description(&info)
+    )))
+}
+
+fn adapter_can_mine(adapter: &wgpu::Adapter, allow_software_adapter: bool) -> bool {
+    allow_software_adapter || !is_software_adapter(adapter)
+}
+
+fn is_software_adapter(adapter: &wgpu::Adapter) -> bool {
+    // Per `wgpu::DeviceType`, `Cpu` means "Cpu / Software Rendering".
+    adapter.get_info().device_type == wgpu::DeviceType::Cpu
+}
+
+pub(super) fn adapter_description(info: &wgpu::AdapterInfo) -> String {
+    let mut details = vec![
+        format!("{:?}", info.device_type),
+        format!("backend: {:?}", info.backend),
+        format!("vendor: 0x{:04x}", info.vendor),
+        format!("device: 0x{:04x}", info.device),
+    ];
+    if !info.driver.is_empty() {
+        details.push(format!("driver: {}", info.driver));
+    }
+    if !info.driver_info.is_empty() {
+        details.push(format!("driver info: {}", info.driver_info));
+    }
+    if info.device_type == wgpu::DeviceType::Cpu {
+        details.push("software renderer".to_owned());
+    }
+
+    format!("{} ({})", info.name, details.join(", "))
+}

--- a/cli/src/gpu/dispatch.rs
+++ b/cli/src/gpu/dispatch.rs
@@ -1,0 +1,89 @@
+// Must match `@workgroup_size(WORKGROUP_SIZE)` in `gpu.wgsl`.
+//
+// A workgroup is the unit of compute work scheduled by the GPU. Each workgroup
+// runs 256 shader invocations, where one invocation is one independent run of
+// the shader on a single candidate salt nonce. 256 is the portable WebGPU
+// default limit for compute invocations per workgroup, so this shader does not
+// need to request any higher device limits.
+pub(super) const WORKGROUP_SIZE: u32 = 256;
+
+// WebGPU caps each compute dispatch dimension at 65,535 workgroups (the
+// `maxComputeWorkgroupsPerDimension` minimum required limit; see
+// https://www.w3.org/TR/webgpu/). We describe the dispatch as rows and columns;
+// at the WebGPU boundary, columns are x and rows are y.
+pub(super) const MAX_WORKGROUP_COLUMNS: u32 = 65_535;
+pub(super) const CANDIDATES_PER_ROW: u32 = WORKGROUP_SIZE * MAX_WORKGROUP_COLUMNS;
+
+// More rows let one GPU submission scan more candidates before the CPU reads
+// the tiny result buffer. The maximum row count is bounded by the requirement
+// that the shader's per-candidate offset (`column + row * candidates_per_row`)
+// fits in a u32.
+// Worst case at this limit:
+//
+//   MAX_WORKGROUP_COLUMNS * WORKGROUP_SIZE * MAX_DISPATCH_ROWS
+//     = 65,535 * 256 * 256
+//     = 4,294,901,760
+//
+// which is just under `u32::MAX` (4,294,967,295). The default row count stays
+// conservative for slower GPUs.
+pub(super) const MAX_DISPATCH_ROWS: u32 = 256;
+pub(super) const DEFAULT_DISPATCH_ROWS: u32 = 8;
+pub(super) const MAX_BATCH_SIZE: u32 = CANDIDATES_PER_ROW * MAX_DISPATCH_ROWS;
+pub(super) const DEFAULT_BATCH_SIZE: u32 = CANDIDATES_PER_ROW * DEFAULT_DISPATCH_ROWS;
+
+#[derive(Copy, Clone, Debug)]
+pub(super) struct DispatchLayout {
+    // One GPU dispatch is a 2D grid.
+    //
+    //     R = candidates_per_row
+    //
+    //              columns: 0 ---------------------- R - 1
+    //            +------------------------------------------+
+    // row 0      | candidates 0 -------------------- R - 1  |
+    // row 1      | candidates R ------------------ 2R - 1  |
+    //   ...      | ...                                      |
+    //            +------------------------------------------+
+    //
+    //     candidate_offset = column + row * R
+    //
+    // Why a rectangle? WebGPU limits one dispatch dimension to 65,535
+    // workgroups. If a request is just one workgroup over that limit, filling
+    // the first row and adding a full second row would almost double the work.
+    // Instead we make the smallest rectangle that holds the request. The
+    // shader still gets dense offsets and does not need an
+    // `offset >= batch_size` branch.
+    //
+    // Actual candidates scanned by this dispatch after rounding.
+    pub(super) candidates: u32,
+    // Workgroup rectangle passed to `dispatch_workgroups(columns, rows, 1)`.
+    pub(super) workgroup_columns: u32,
+    pub(super) workgroup_rows: u32,
+    // Candidate count in one dispatch row.
+    pub(super) candidates_per_row: u32,
+}
+
+impl DispatchLayout {
+    pub(super) fn for_requested_candidates(requested_candidates: u32) -> Self {
+        let requested_candidates = requested_candidates.clamp(WORKGROUP_SIZE, MAX_BATCH_SIZE);
+        let requested_workgroups = requested_candidates.div_ceil(WORKGROUP_SIZE);
+
+        // WebGPU caps a dispatch dimension at 65,535 workgroups. When the
+        // request needs more than one row, use the fewest rows needed, then
+        // spread the columns evenly across those rows. For example, one row
+        // plus one workgroup becomes 32,768 columns x 2 rows, not 65,535 x 2.
+        // That keeps the shader branch-free without doing a lot of unrequested
+        // work.
+        let workgroup_rows = requested_workgroups.div_ceil(MAX_WORKGROUP_COLUMNS);
+        let workgroup_columns = requested_workgroups.div_ceil(workgroup_rows);
+        let dispatched_workgroups = workgroup_columns * workgroup_rows;
+
+        debug_assert!(workgroup_columns <= MAX_WORKGROUP_COLUMNS);
+        debug_assert!(workgroup_rows <= MAX_DISPATCH_ROWS);
+        Self {
+            candidates: dispatched_workgroups * WORKGROUP_SIZE,
+            workgroup_columns,
+            workgroup_rows,
+            candidates_per_row: workgroup_columns * WORKGROUP_SIZE,
+        }
+    }
+}

--- a/cli/src/gpu/input.rs
+++ b/cli/src/gpu/input.rs
@@ -1,0 +1,97 @@
+use super::dispatch::DispatchLayout;
+use deadbeef_core::SearchContext;
+use std::mem;
+
+pub(super) const GPU_INPUT_WORDS: usize = 36;
+pub(super) const GPU_RESULT_WORDS: usize = 9;
+
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+pub(super) struct GpuInput {
+    // Host-side storage-buffer layout. Keep this field order in sync with
+    // `struct Input` in `gpu.wgsl`; the tests below pin the host word offsets.
+    pub(super) initializer_hash: [u32; 8],
+    pub(super) factory: [u32; 5],
+    pub(super) init_code_hash: [u32; 8],
+    pub(super) prefix: [u32; 5],
+    // First 24 bytes of the 32-byte Safe salt nonce. The final 8 bytes are the
+    // counter in big-endian byte order: high bytes first, then low bytes.
+    pub(super) nonce_prefix: [u32; 6],
+    pub(super) prefix_len: u32,
+    // Candidate count in one dispatch row.
+    pub(super) candidates_per_row: u32,
+    pub(super) counter_low: u32,
+    pub(super) counter_high: u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+pub(super) struct GpuResult {
+    // Host-side storage-buffer layout. Keep this field order in sync with
+    // `struct ResultBuffer` in `gpu.wgsl`; the tests below pin the host word
+    // offsets.
+    pub(super) found: u32,
+    pub(super) nonce: [u32; 8],
+}
+
+const _: () = {
+    assert!(mem::size_of::<GpuInput>() == GPU_INPUT_WORDS * mem::size_of::<u32>());
+    assert!(mem::align_of::<GpuInput>() == mem::align_of::<u32>());
+    assert!(mem::size_of::<GpuResult>() == GPU_RESULT_WORDS * mem::size_of::<u32>());
+    assert!(mem::align_of::<GpuResult>() == mem::align_of::<u32>());
+};
+
+impl GpuInput {
+    pub(super) fn for_search(
+        context: &SearchContext,
+        prefix: &[u8],
+        nonce_prefix: &[u8; 24],
+        dispatch: DispatchLayout,
+    ) -> Self {
+        Self {
+            initializer_hash: pack_words(&context.initializer_hash),
+            factory: pack_words(&context.factory.0),
+            init_code_hash: pack_words(&context.init_code_hash),
+            prefix: pack_words(prefix),
+            nonce_prefix: pack_words(nonce_prefix),
+            prefix_len: prefix.len() as u32,
+            candidates_per_row: dispatch.candidates_per_row,
+            counter_low: 0,
+            counter_high: 0,
+        }
+    }
+
+    // The shader receives the counter split into two u32 values because WGSL
+    // u64 support is not portable across all wgpu backends.
+    pub(super) fn set_counter(&mut self, counter: u64) {
+        self.counter_low = counter as u32;
+        self.counter_high = (counter >> 32) as u32;
+    }
+}
+
+pub(super) fn pack_words<const N: usize>(bytes: &[u8]) -> [u32; N] {
+    // Pack host byte strings into the same little-endian u32 words used by WGSL
+    // and Keccak lanes. Keccak's spec stores each 64-bit lane as little-endian
+    // bytes, which is the same byte order WGSL uses inside a u32, so the host
+    // packing matches the shader's view without any extra swapping. See the
+    // `GpuInput` layout note above for the full host/device ABI. Missing bytes
+    // remain zero, which is useful for shorter prefixes.
+    let mut words = [0_u32; N];
+    for (index, byte) in bytes.iter().copied().take(N * 4).enumerate() {
+        words[index / 4] |= u32::from(byte) << ((index % 4) * 8);
+    }
+    words
+}
+
+pub(super) fn unpack_words<const WORDS: usize, const BYTES: usize>(
+    words: [u32; WORDS],
+) -> [u8; BYTES] {
+    // Inverse of `pack_words`, used for the nonce returned by the shader before
+    // CPU verification. The output must fit inside the input words.
+    debug_assert!(BYTES <= WORDS * 4);
+    let mut bytes = [0_u8; BYTES];
+    for (index, byte) in bytes.iter_mut().enumerate() {
+        *byte = ((words[index / 4] >> ((index % 4) * 8)) & 0xff) as u8;
+    }
+    bytes
+}

--- a/cli/src/gpu/miner.rs
+++ b/cli/src/gpu/miner.rs
@@ -1,0 +1,230 @@
+use super::{
+    adapter::select_adapter,
+    dispatch::DispatchLayout,
+    input::{unpack_words, GpuInput, GpuResult},
+    Backend, Result,
+};
+use bytemuck::Zeroable as _;
+use std::{borrow::Cow, mem, sync::mpsc};
+
+pub(super) const SHADER: &str = include_str!("../gpu.wgsl");
+
+pub(super) struct Miner {
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    pipeline: wgpu::ComputePipeline,
+    bind_group: wgpu::BindGroup,
+    input_buffer: wgpu::Buffer,
+    result_buffer: wgpu::Buffer,
+    read_buffer: wgpu::Buffer,
+}
+
+pub(super) struct MinerGuard {
+    miner: Option<Miner>,
+    backend: Backend,
+}
+
+impl MinerGuard {
+    pub(super) fn new(miner: Miner, backend: Backend) -> Self {
+        Self {
+            miner: Some(miner),
+            backend,
+        }
+    }
+}
+
+impl std::ops::Deref for MinerGuard {
+    type Target = Miner;
+
+    fn deref(&self) -> &Self::Target {
+        self.miner
+            .as_ref()
+            .expect("miner should exist until its guard drops")
+    }
+}
+
+impl Drop for MinerGuard {
+    fn drop(&mut self) {
+        if self.backend == Backend::Gl {
+            // Mesa's GL-over-D3D12 path on WSL has been observed crashing during
+            // device teardown. The CLI exits immediately after mining, so
+            // leaking only this GL device avoids losing the mined result during
+            // shutdown cleanup. If the driver or wgpu teardown path changes,
+            // verify GL mining and remove this workaround.
+            if let Some(miner) = self.miner.take() {
+                mem::forget(miner);
+            }
+        }
+    }
+}
+
+impl Miner {
+    // Open a session with the GPU and prepare the resources the miner reuses
+    // across batches.
+    //
+    // wgpu vocabulary used below:
+    // - an *adapter* is a specific physical GPU + driver combination wgpu can
+    //   open (e.g. "Apple M3 Max via Metal");
+    // - a *device* is our open handle to that adapter, scoped to this process;
+    // - a *queue* is where we submit commands (each batch is one submission);
+    // - a *shader module* is the compiled WGSL program;
+    // - a *compute pipeline* binds a shader entry point to fixed pipeline
+    //   state (workgroup size, layout);
+    // - *buffers* are GPU-visible memory regions; *bind groups* tell the
+    //   shader which buffers to read and write.
+    pub(super) fn new(
+        backend: Backend,
+        adapter_index: Option<usize>,
+        allow_software_adapter: bool,
+    ) -> Result<Self> {
+        let adapter = select_adapter(backend, adapter_index, allow_software_adapter)?;
+        let (device, queue) =
+            pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+                label: Some("deadbeef GPU miner"),
+                required_features: wgpu::Features::empty(),
+                required_limits: wgpu::Limits::default(),
+                experimental_features: wgpu::ExperimentalFeatures::disabled(),
+                memory_hints: wgpu::MemoryHints::Performance,
+                trace: wgpu::Trace::Off,
+            }))?;
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("deadbeef Keccak miner"),
+            source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(SHADER)),
+        });
+        let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("deadbeef GPU miner pipeline"),
+            layout: None,
+            module: &shader,
+            entry_point: Some("main"),
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+            cache: None,
+        });
+
+        let input_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("deadbeef GPU input"),
+            size: mem::size_of::<GpuInput>() as wgpu::BufferAddress,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let result_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("deadbeef GPU result"),
+            size: mem::size_of::<GpuResult>() as wgpu::BufferAddress,
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_DST
+                | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let read_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("deadbeef GPU result readback"),
+            size: mem::size_of::<GpuResult>() as wgpu::BufferAddress,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let bind_group_layout = pipeline.get_bind_group_layout(0);
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("deadbeef GPU miner bind group"),
+            layout: &bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: input_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: result_buffer.as_entire_binding(),
+                },
+            ],
+        });
+
+        Ok(Self {
+            device,
+            queue,
+            pipeline,
+            bind_group,
+            input_buffer,
+            result_buffer,
+            read_buffer,
+        })
+    }
+
+    // Run one batch of candidates on the GPU. Returns `Some(nonce)` if the
+    // shader claimed a match in this batch, or `None` if the batch finished
+    // with no match.
+    //
+    // wgpu vocabulary used below:
+    // - a *command encoder* records GPU commands without running them;
+    // - a *compute pass* is a phase inside that recording where the GPU runs
+    //   our shader for one dispatch;
+    // - a *bind group* hands the shader the buffers we want it to read/write;
+    // - a *buffer slice* + `map_async` is how we ask the GPU to make a
+    //   buffer's bytes visible to the CPU once submitted work has finished.
+    //
+    // Each batch is synchronous from the caller's perspective: write the
+    // input, clear the result slot, dispatch the shader, copy the result into
+    // a CPU-mappable buffer, and wait for readback. The heavy work stays on
+    // the GPU; the synchronous readback is one small `GpuResult` (36 bytes)
+    // per batch.
+    pub(super) fn run_batch(
+        &self,
+        input: &GpuInput,
+        dispatch: &DispatchLayout,
+    ) -> Result<Option<[u8; 32]>> {
+        self.queue
+            .write_buffer(&self.input_buffer, 0, bytemuck::bytes_of(input));
+        self.queue.write_buffer(
+            &self.result_buffer,
+            0,
+            bytemuck::bytes_of(&GpuResult::zeroed()),
+        );
+
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("deadbeef GPU miner command encoder"),
+            });
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some("deadbeef GPU miner pass"),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(&self.pipeline);
+            pass.set_bind_group(0, &self.bind_group, &[]);
+            pass.dispatch_workgroups(dispatch.workgroup_columns, dispatch.workgroup_rows, 1);
+        }
+        encoder.copy_buffer_to_buffer(
+            &self.result_buffer,
+            0,
+            &self.read_buffer,
+            0,
+            mem::size_of::<GpuResult>() as wgpu::BufferAddress,
+        );
+        self.queue.submit(Some(encoder.finish()));
+
+        let slice = self.read_buffer.slice(..);
+        let (sender, receiver) = mpsc::channel();
+        slice.map_async(wgpu::MapMode::Read, move |result| {
+            let _ = sender.send(result);
+        });
+        self.device.poll(wgpu::PollType::Wait {
+            submission_index: None,
+            timeout: None,
+        })?;
+        match receiver.recv() {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => return Err(Box::new(err)),
+            Err(err) => return Err(Box::new(err)),
+        }
+
+        let data = slice.get_mapped_range();
+        let result = *bytemuck::from_bytes::<GpuResult>(&data);
+        drop(data);
+        self.read_buffer.unmap();
+
+        if result.found == 0 {
+            return Ok(None);
+        }
+        Ok(Some(unpack_words(result.nonce)))
+    }
+}

--- a/cli/src/gpu/tests.rs
+++ b/cli/src/gpu/tests.rs
@@ -1,0 +1,280 @@
+use super::{
+    adapter::adapters,
+    dispatch::{
+        DispatchLayout, CANDIDATES_PER_ROW, DEFAULT_BATCH_SIZE, DEFAULT_DISPATCH_ROWS,
+        MAX_BATCH_SIZE, MAX_WORKGROUP_COLUMNS, WORKGROUP_SIZE,
+    },
+    input::{GpuInput, GpuResult, GPU_INPUT_WORDS, GPU_RESULT_WORDS},
+    miner::{Miner, MinerGuard, SHADER},
+    Backend,
+};
+use deadbeef_core::{config, Configuration, Safe, SearchContext};
+use std::{mem, time::Instant};
+
+const BENCH_BATCHES: u32 = 128;
+// Keep the ignored benchmark quick unless the caller opts into a larger batch.
+const DEFAULT_BENCH_BATCH_SIZE: u32 = 1_048_576;
+
+fn test_safe() -> Safe {
+    Safe::new(Configuration {
+        proxy: config::Proxy {
+            factory: "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67"
+                .parse()
+                .unwrap(),
+            init_code: vec![],
+            singleton: "0x41675C099F32341bf84BFc5382aF534df5C7461a"
+                .parse()
+                .unwrap(),
+        },
+        account: config::Account {
+            owners: vec!["0x1111111111111111111111111111111111111111"
+                .parse()
+                .unwrap()],
+            threshold: 1,
+            setup: None,
+            fallback_handler: None,
+            identifier: None,
+        },
+    })
+}
+
+fn primary_miner() -> Option<MinerGuard> {
+    if !primary_adapter_available() {
+        return None;
+    }
+
+    Some(MinerGuard::new(
+        Miner::new(Backend::Primary, None, true).unwrap(),
+        Backend::Primary,
+    ))
+}
+
+fn primary_adapter_available() -> bool {
+    !adapters(Backend::Primary).is_empty()
+}
+
+fn hardware_adapter_available(backend: Backend) -> bool {
+    adapters(backend)
+        .iter()
+        .any(|adapter| adapter.get_info().device_type != wgpu::DeviceType::Cpu)
+}
+
+fn benchmark_backend() -> Backend {
+    match std::env::var("DEADBEEF_GPU_BENCH_BACKEND").as_deref() {
+        Ok("metal") => Backend::Metal,
+        Ok("vulkan") => Backend::Vulkan,
+        Ok("dx12") => Backend::Dx12,
+        Ok("gl") => Backend::Gl,
+        Ok("primary") | Err(_) => Backend::Primary,
+        Ok(backend) => panic!("unsupported DEADBEEF_GPU_BENCH_BACKEND={backend}"),
+    }
+}
+
+fn benchmark_miner() -> Option<MinerGuard> {
+    let backend = benchmark_backend();
+    if !hardware_adapter_available(backend) {
+        return None;
+    }
+
+    Some(MinerGuard::new(
+        Miner::new(backend, None, false).unwrap(),
+        backend,
+    ))
+}
+
+fn fixed_nonce_prefix() -> [u8; 24] {
+    [
+        0x10, 0x32, 0x54, 0x76, 0x98, 0xba, 0xdc, 0xfe, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd,
+        0xef, 0xf0, 0xde, 0xbc, 0x9a, 0x78, 0x56, 0x34, 0x12,
+    ]
+}
+
+fn nonce_from_counter(nonce_prefix: [u8; 24], counter: u64) -> [u8; 32] {
+    let mut nonce = [0_u8; 32];
+    nonce[0..24].copy_from_slice(&nonce_prefix);
+    nonce[24..32].copy_from_slice(&counter.to_be_bytes());
+    nonce
+}
+
+fn assert_gpu_finds_planted_nonce(
+    miner: &Miner,
+    context: &SearchContext,
+    nonce_prefix: [u8; 24],
+    start_counter: u64,
+    offset: u32,
+) {
+    let expected_counter = start_counter + u64::from(offset);
+    let expected_nonce = nonce_from_counter(nonce_prefix, expected_counter);
+    let expected_address = context.creation_address(expected_nonce);
+    let dispatch = DispatchLayout::for_requested_candidates(WORKGROUP_SIZE);
+
+    let mut input = GpuInput::for_search(context, &expected_address.0, &nonce_prefix, dispatch);
+    input.set_counter(start_counter);
+    let found_nonce = miner
+        .run_batch(&input, &dispatch)
+        .unwrap()
+        .expect("GPU did not find the planted nonce");
+
+    assert_eq!(found_nonce, expected_nonce);
+    assert_eq!(context.creation_address(found_nonce), expected_address);
+}
+
+fn rounded(requested: u32) -> u32 {
+    DispatchLayout::for_requested_candidates(requested).candidates
+}
+
+fn word_offset(byte_offset: usize) -> usize {
+    assert_eq!(byte_offset % mem::size_of::<u32>(), 0);
+    byte_offset / mem::size_of::<u32>()
+}
+
+#[test]
+fn rounds_batch_size_to_workgroups() {
+    assert_eq!(rounded(1), WORKGROUP_SIZE);
+    assert_eq!(rounded(WORKGROUP_SIZE + 1), WORKGROUP_SIZE * 2);
+    assert_eq!(
+        rounded(CANDIDATES_PER_ROW + 1),
+        CANDIDATES_PER_ROW + WORKGROUP_SIZE
+    );
+    assert_eq!(rounded(u32::MAX), MAX_BATCH_SIZE);
+}
+
+#[test]
+fn lays_out_multi_row_dispatches_densely() {
+    let dispatch = DispatchLayout::for_requested_candidates(CANDIDATES_PER_ROW + 1);
+    assert_eq!(dispatch.candidates, CANDIDATES_PER_ROW + WORKGROUP_SIZE);
+    assert_eq!(dispatch.workgroup_columns, 32_768);
+    assert_eq!(dispatch.workgroup_rows, 2);
+    assert_eq!(dispatch.candidates_per_row, 32_768 * WORKGROUP_SIZE);
+
+    let dispatch = DispatchLayout::for_requested_candidates(DEFAULT_BATCH_SIZE);
+    assert_eq!(dispatch.candidates, DEFAULT_BATCH_SIZE);
+    assert_eq!(dispatch.workgroup_columns, MAX_WORKGROUP_COLUMNS);
+    assert_eq!(dispatch.workgroup_rows, DEFAULT_DISPATCH_ROWS);
+    assert_eq!(dispatch.candidates_per_row, CANDIDATES_PER_ROW);
+}
+
+#[test]
+fn shader_workgroup_size_matches_host() {
+    assert_eq!(WORKGROUP_SIZE, 256);
+    let shader_workgroup_size = SHADER
+        .lines()
+        .find_map(|line| {
+            let line = line.trim();
+            line.strip_prefix("const WORKGROUP_SIZE: u32 = ")
+                .and_then(|value| value.strip_suffix("u;"))
+                .and_then(|value| value.parse::<u32>().ok())
+        })
+        .expect("shader should define WORKGROUP_SIZE");
+    assert_eq!(shader_workgroup_size, WORKGROUP_SIZE);
+}
+
+#[test]
+fn host_input_layout_matches_shader_contract() {
+    assert_eq!(
+        mem::size_of::<GpuInput>(),
+        GPU_INPUT_WORDS * mem::size_of::<u32>()
+    );
+    assert_eq!(mem::offset_of!(GpuInput, initializer_hash), 0);
+    assert_eq!(word_offset(mem::offset_of!(GpuInput, factory)), 8);
+    assert_eq!(word_offset(mem::offset_of!(GpuInput, init_code_hash)), 13);
+    assert_eq!(word_offset(mem::offset_of!(GpuInput, prefix)), 21);
+    assert_eq!(word_offset(mem::offset_of!(GpuInput, nonce_prefix)), 26);
+    assert_eq!(word_offset(mem::offset_of!(GpuInput, prefix_len)), 32);
+    assert_eq!(
+        word_offset(mem::offset_of!(GpuInput, candidates_per_row)),
+        33
+    );
+    assert_eq!(word_offset(mem::offset_of!(GpuInput, counter_low)), 34);
+    assert_eq!(word_offset(mem::offset_of!(GpuInput, counter_high)), 35);
+}
+
+#[test]
+fn host_result_layout_matches_shader_contract() {
+    assert_eq!(
+        mem::size_of::<GpuResult>(),
+        GPU_RESULT_WORDS * mem::size_of::<u32>()
+    );
+    assert_eq!(word_offset(mem::offset_of!(GpuResult, found)), 0);
+    assert_eq!(word_offset(mem::offset_of!(GpuResult, nonce)), 1);
+}
+
+#[test]
+fn gpu_derivation_matches_cpu_for_counter_byte_order_and_carry() {
+    let safe = test_safe();
+    let context = safe.search_context();
+    let Some(miner) = primary_miner() else {
+        return;
+    };
+
+    for (start_counter, offset) in [(0x0102_0304_0506_0708, 0), (u64::from(u32::MAX), 1)] {
+        assert_gpu_finds_planted_nonce(
+            &miner,
+            &context,
+            fixed_nonce_prefix(),
+            start_counter,
+            offset,
+        );
+    }
+}
+
+#[test]
+fn gpu_matches_every_address_prefix_length() {
+    let safe = test_safe();
+    let context = safe.search_context();
+    let Some(miner) = primary_miner() else {
+        return;
+    };
+    let nonce_prefix = fixed_nonce_prefix();
+    let expected_nonce = nonce_from_counter(nonce_prefix, 0x0102_0304_0506_0708);
+    let expected_address = context.creation_address(expected_nonce);
+    let dispatch = DispatchLayout::for_requested_candidates(WORKGROUP_SIZE);
+
+    for prefix_len in 1..=20 {
+        let prefix = &expected_address.0[..prefix_len];
+        let mut input = GpuInput::for_search(&context, prefix, &nonce_prefix, dispatch);
+        input.set_counter(0x0102_0304_0506_0708);
+        let found_nonce = miner
+            .run_batch(&input, &dispatch)
+            .unwrap()
+            .expect("GPU did not find any nonce for planted prefix");
+        assert!(
+            context.creation_address(found_nonce).0.starts_with(prefix),
+            "GPU returned a nonce that does not match a {prefix_len}-byte prefix",
+        );
+    }
+}
+
+#[test]
+#[ignore = "requires a GPU adapter and prints throughput"]
+fn gpu_benchmark_fixed_batches() {
+    let safe = test_safe();
+    let context = safe.search_context();
+    let Some(miner) = benchmark_miner() else {
+        return;
+    };
+    let nonce_prefix = fixed_nonce_prefix();
+
+    let start = Instant::now();
+    let batch_size = std::env::var("DEADBEEF_GPU_BENCH_BATCH_SIZE")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(DEFAULT_BENCH_BATCH_SIZE);
+    let dispatch = DispatchLayout::for_requested_candidates(batch_size);
+    let batch_size = dispatch.candidates;
+    let mut input = GpuInput::for_search(&context, &[0xff; 20], &nonce_prefix, dispatch);
+
+    for batch in 0..BENCH_BATCHES {
+        let counter = u64::from(batch) * u64::from(batch_size);
+        input.set_counter(counter);
+        let result = miner.run_batch(&input, &dispatch).unwrap();
+        assert!(result.is_none());
+    }
+
+    let elapsed = start.elapsed().as_secs_f64();
+    let candidates = u64::from(BENCH_BATCHES) * u64::from(batch_size);
+    eprintln!(
+        "gpu benchmark: {candidates} candidates ({BENCH_BATCHES} x {batch_size}) in {elapsed:.3}s = {:.2} Maddr/s",
+        candidates as f64 / elapsed / 1_000_000.0
+    );
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,6 @@
 mod chain;
 mod deployment;
+mod gpu;
 
 use self::chain::{Chain, Singleton};
 use chain::Details;
@@ -10,8 +11,9 @@ use std::{num::NonZeroUsize, process, str::FromStr, sync::mpsc, thread};
 
 /// Generate vanity addresses for Safe deployments.
 #[derive(Clone, Parser)]
+#[command(group(clap::ArgGroup::new("gpu_mode").args(["gpu", "list_gpus"])))]
 struct Args {
-    /// The number of parallel threads to use. Defaults to the number of CPUs.
+    /// Number of CPU mining threads to use. Ignored when `--gpu` is set.
     #[arg(short = 'n', long, default_value_t = num_cpus::get())]
     threads: usize,
 
@@ -19,7 +21,12 @@ struct Args {
     ///
     /// Can be specified multiple times in order to specify multiple owners.
     /// They will be included in the provided order.
-    #[arg(short, long = "owner", required = true, num_args = 1..)]
+    #[arg(
+        short,
+        long = "owner",
+        required_unless_present = "list_gpus",
+        num_args = 1..
+    )]
     owners: Vec<NonZeroAddress>,
 
     /// Owner signature threshold.
@@ -27,8 +34,8 @@ struct Args {
     threshold: usize,
 
     /// The prefix to look for.
-    #[arg(short, long)]
-    prefix: Hex,
+    #[arg(short, long, required_unless_present = "list_gpus")]
+    prefix: Option<Hex>,
 
     /// The chain ID to find a vanity Safe address for. If the chain is not
     /// supported, then all of '--proxy-factory', '--proxy-init-code', and
@@ -69,6 +76,41 @@ struct Args {
     #[arg(long)]
     fallback_handler: Option<NonZeroAddress>,
 
+    /// Mine using a GPU.
+    #[arg(long)]
+    gpu: bool,
+
+    /// List available GPU adapters and exit.
+    #[arg(long)]
+    list_gpus: bool,
+
+    /// Select the GPU backend to use. `gl` is a fallback path; the current CLI
+    /// exits without tearing down a GL miner before process exit.
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = gpu::Backend::Primary,
+        requires = "gpu_mode"
+    )]
+    gpu_backend: gpu::Backend,
+
+    /// Select the GPU adapter index from `--list-gpus`.
+    #[arg(long, requires = "gpu", conflicts_with = "list_gpus")]
+    gpu_adapter: Option<usize>,
+
+    /// Requested GPU candidates per dispatch. Rounded to a supported size.
+    #[arg(
+        long,
+        default_value_t = gpu::DEFAULT_BATCH_SIZE,
+        requires = "gpu",
+        conflicts_with = "list_gpus"
+    )]
+    gpu_batch_size: u32,
+
+    /// Allow software-rendered GPU adapters. Intended for tests and diagnostics.
+    #[arg(long, hide = true, requires = "gpu", conflicts_with = "list_gpus")]
+    allow_software_gpu: bool,
+
     /// Quiet mode.
     ///
     /// Only output the transaction calldata without any extra information.
@@ -101,8 +143,30 @@ impl FromStr for Hex {
     }
 }
 
+fn validate_prefix(prefix: &[u8]) -> Result<(), &'static str> {
+    if prefix.len() > 20 {
+        Err("prefix cannot be longer than an Ethereum address")
+    } else {
+        Ok(())
+    }
+}
+
 fn main() {
     let args = Args::parse();
+
+    if args.list_gpus {
+        if let Err(err) = gpu::list_adapters(args.gpu_backend) {
+            eprintln!("error: {err}");
+            process::exit(1);
+        }
+        process::exit(0);
+    }
+
+    let prefix = args.prefix.expect("missing prefix");
+    if let Err(err) = validate_prefix(&prefix.0) {
+        eprintln!("error: {err}");
+        process::exit(2);
+    }
 
     let threads = NonZeroUsize::new(args.threads);
     let chain = args.chain.details();
@@ -178,8 +242,25 @@ fn main() {
         .expect("unsupported chain");
     let explorer = chain.as_ref().map(Details::explorer);
 
-    let setup = || (Safe::new(config.clone()), args.prefix.0.clone());
-    let safe = if let Some(threads) = threads {
+    let setup = || (Safe::new(config.clone()), prefix.0.clone());
+    let safe = if args.gpu {
+        let mut safe = Safe::new(config.clone());
+        if let Err(err) = gpu::search(
+            &mut safe,
+            &prefix.0,
+            gpu::Options {
+                backend: args.gpu_backend,
+                adapter: args.gpu_adapter,
+                batch_size: args.gpu_batch_size,
+                allow_software_adapter: args.allow_software_gpu,
+                progress: !args.quiet,
+            },
+        ) {
+            eprintln!("GPU mining failed: {err}");
+            process::exit(1);
+        }
+        safe
+    } else if let Some(threads) = threads {
         let (sender, receiver) = mpsc::channel();
         let _threads = (0..threads.get())
             .map(|_| {
@@ -246,4 +327,100 @@ fn main() {
     }
 
     process::exit(0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_gpus_does_not_require_safe_config() {
+        let args = Args::try_parse_from(["deadbeef", "--list-gpus"]).unwrap();
+        assert!(args.list_gpus);
+    }
+
+    #[test]
+    fn parses_gpu_options() {
+        let args = Args::try_parse_from([
+            "deadbeef",
+            "--owner",
+            "0x1111111111111111111111111111111111111111",
+            "--prefix",
+            "0x00",
+            "--gpu",
+            "--gpu-backend",
+            "metal",
+            "--gpu-adapter",
+            "1",
+            "--gpu-batch-size",
+            "257",
+        ])
+        .unwrap();
+
+        assert!(args.gpu);
+        assert_eq!(args.gpu_backend, gpu::Backend::Metal);
+        assert_eq!(args.gpu_adapter, Some(1));
+        assert_eq!(args.gpu_batch_size, 257);
+    }
+
+    #[test]
+    fn gpu_options_require_gpu_mode() {
+        for args in [
+            &[
+                "deadbeef",
+                "--owner",
+                "0x1111111111111111111111111111111111111111",
+                "--prefix",
+                "0x00",
+                "--gpu-backend",
+                "metal",
+            ][..],
+            &[
+                "deadbeef",
+                "--owner",
+                "0x1111111111111111111111111111111111111111",
+                "--prefix",
+                "0x00",
+                "--gpu-adapter",
+                "0",
+            ],
+            &[
+                "deadbeef",
+                "--owner",
+                "0x1111111111111111111111111111111111111111",
+                "--prefix",
+                "0x00",
+                "--gpu-batch-size",
+                "257",
+            ],
+        ] {
+            assert!(Args::try_parse_from(args).is_err());
+        }
+    }
+
+    #[test]
+    fn list_gpus_accepts_gpu_backend() {
+        let args =
+            Args::try_parse_from(["deadbeef", "--list-gpus", "--gpu-backend", "gl"]).unwrap();
+
+        assert!(args.list_gpus);
+        assert_eq!(args.gpu_backend, gpu::Backend::Gl);
+    }
+
+    #[test]
+    fn list_gpus_rejects_unused_gpu_batch_size() {
+        assert!(
+            Args::try_parse_from(["deadbeef", "--list-gpus", "--gpu-batch-size", "257"]).is_err()
+        );
+    }
+
+    #[test]
+    fn list_gpus_rejects_unused_gpu_adapter() {
+        assert!(Args::try_parse_from(["deadbeef", "--list-gpus", "--gpu-adapter", "0"]).is_err());
+    }
+
+    #[test]
+    fn rejects_overlong_prefixes() {
+        assert!(validate_prefix(&[0; 21]).is_err());
+    }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -8,7 +8,7 @@ mod safe;
 pub use self::{
     address::{Address, NonZeroAddress},
     config::Configuration,
-    safe::{Safe, Transaction},
+    safe::{Safe, SearchContext, Transaction},
 };
 pub use hex_literal::hex;
 use rand::{rngs::SmallRng, Rng as _, SeedableRng as _};

--- a/core/src/safe.rs
+++ b/core/src/safe.rs
@@ -20,6 +20,28 @@ pub struct Transaction {
     pub calldata: Vec<u8>,
 }
 
+/// Fixed inputs for mining Safe creation addresses.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct SearchContext {
+    /// The Keccak-256 hash of the Safe initializer calldata.
+    pub initializer_hash: [u8; 32],
+    /// The `SafeProxyFactory` address.
+    pub factory: Address,
+    /// The `CREATE2` init code hash for the Safe proxy deployment.
+    pub init_code_hash: [u8; 32],
+}
+
+impl SearchContext {
+    /// Computes the Safe creation address for the specified salt nonce.
+    pub fn creation_address(&self, salt_nonce: [u8; 32]) -> Address {
+        let mut salt = [0_u8; 64];
+        salt[0..32].copy_from_slice(&self.initializer_hash);
+        salt[32..64].copy_from_slice(&salt_nonce);
+
+        Create2::new(self.factory, keccak::v256(&salt), self.init_code_hash).creation_address()
+    }
+}
+
 impl Safe {
     /// Creates a new safe from spcified configuration.
     pub fn new(config: Configuration) -> Self {
@@ -63,10 +85,21 @@ impl Safe {
         &self.initializer
     }
 
+    /// Returns the fixed search context for mining salt nonces.
+    pub fn search_context(&self) -> SearchContext {
+        SearchContext {
+            initializer_hash: self.salt[0..32].try_into().unwrap(),
+            factory: self.config.proxy.factory.get(),
+            init_code_hash: self.config.proxy.init_code_hash(),
+        }
+    }
+
     /// Updates the salt nonce and recomputes the `CREATE2` salt.
     pub fn update_salt_nonce(&mut self, f: impl FnOnce(&mut [u8; 32])) {
-        let salt_nonce = unsafe { &mut *self.salt.get_unchecked_mut(32..).as_mut_ptr().cast() };
-        f(salt_nonce);
+        {
+            let salt_nonce: &mut [u8; 32] = (&mut self.salt[32..64]).try_into().unwrap();
+            f(salt_nonce);
+        }
         *self.create2.salt_mut() = keccak::v256(&self.salt);
     }
 
@@ -87,6 +120,34 @@ mod tests {
     use super::*;
     use crate::config;
     use hex_literal::hex;
+
+    #[test]
+    fn search_context_matches_safe_creation_address() {
+        let mut safe = Safe::new(Configuration {
+            proxy: config::Proxy {
+                factory: address!(nz "1111111111111111111111111111111111111111"),
+                init_code: vec![0xab, 0xcd, 0xef],
+                singleton: address!(nz "2222222222222222222222222222222222222222"),
+            },
+            account: config::Account {
+                owners: vec![
+                    address!(nz "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                    address!(nz "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+                ],
+                threshold: 1,
+                setup: None,
+                fallback_handler: None,
+                identifier: None,
+            },
+        });
+        let context = safe.search_context();
+
+        for byte in [0x00, 0x01, 0x7f, 0xff] {
+            let nonce = [byte; 32];
+            safe.update_salt_nonce(|n| *n = nonce);
+            assert_eq!(context.creation_address(nonce), safe.creation_address());
+        }
+    }
 
     #[test]
     fn transaction() {


### PR DESCRIPTION
# Add Opt-In GPU Mining for Safe Vanity Addresses

## Summary

This branch adds an optional GPU mining mode to `deadbeef`.

The normal CPU miner is still available and remains the source of truth. When GPU mining is enabled, the GPU quickly scans possible Safe salt nonce values and returns a possible match. The CPU then checks that candidate again before the CLI prints the final address and transaction data.

The GPU work was inspired by [`create2crunch`](https://github.com/0age/create2crunch).

## What This Unlocks

The practical win is that longer vanity prefixes become realistic on consumer-grade GPU hardware.

Using the RTX 5090 benchmark in the README, the GPU miner checks about 2.2 billion candidate addresses per second. The same machine has a 12-core CPU. If we take the README's single-thread CPU benchmark and assume perfect scaling across all 12 physical cores, the GPU is still about 107x faster.

At that speed, a 5-byte prefix such as `0x5afe000000`, `0xdeadbeef00`, or `0x0000000000` takes about 8 minutes on average on the GPU. With the optimistic 12-core CPU estimate above, the same search would take about 15 hours.

A 6-byte prefix such as `0x5afe00000000` is still much harder. On the same RTX 5090 benchmark, it is closer to a day and a half on average. With the same optimistic 12-core CPU estimate, it would be closer to 5 months. So this change does not make every vanity address cheap, but it moves useful 5-byte prefixes into the "run it over lunch" range and makes some longer searches possible without a dedicated mining setup.

## Important Safety Note

The GPU kernel was written with the assistance of AI.

The Keccak hashing function inside the GPU shader has not been cryptographically verified. Because of that, we do not treat the GPU result as trusted on its own.

Instead, the CPU implementation is always treated as the known-good implementation. The GPU only proposes a candidate. Before returning a result, the CLI uses the CPU code to recompute the Safe address and confirm that it really matches the requested prefix.

If the GPU ever returns a wrong candidate, the CLI reports an error instead of printing unsafe deployment data.

## What Changed

- Added `--gpu` to mine Safe vanity addresses with a GPU.
- Added `--list-gpus` to show the GPU adapters available through `wgpu`.
- Added `--gpu-backend` so users can choose the backend, including `metal`, `vulkan`, `dx12`, and `gl`.
- Added `--gpu-adapter` so users can select a specific GPU from the adapter list.
- Added `--gpu-batch-size` so users can tune how many candidate addresses are checked in one GPU dispatch.
- Added a hidden `--allow-software-gpu` flag for tests and diagnostics.
- Kept CPU mining as the default behaviour.
- Kept `--quiet` compatible with GPU mining by suppressing GPU progress output.
- Documented GPU usage, backend selection, batch-size tuning, and reference benchmark results in the README.

## How GPU Mining Works

The CPU still builds the Safe configuration, initialiser, factory address, and proxy init code hash.

For GPU mining, the CPU sends the fixed search inputs to the GPU:

- the Safe initialiser hash
- the Safe proxy factory address
- the Safe proxy init code hash
- the requested address prefix
- a random salt nonce prefix
- a counter range to scan

The GPU checks many counter values in parallel. Each counter becomes the last 8 bytes of the Safe salt nonce. If the shader finds a value that appears to create an address with the requested prefix, it writes that nonce into a small result buffer.

The CPU reads the candidate nonce, recomputes the Safe address using the existing Rust implementation, and accepts the result only if the CPU-computed address matches the requested prefix.

## Implementation Details

- Added a new `cli/src/gpu` module split into adapter selection, dispatch layout, host/GPU input packing, mining, and tests.
- Added `cli/src/gpu.wgsl`, which contains the compute shader used by the GPU miner.
- Added `SearchContext` in `deadbeef-core` so the CLI can share fixed Safe address search inputs with the GPU path without moving full Safe setup logic into the shader.
- Added `Safe::search_context()` and `Safe::update_salt_nonce()` helpers so both CPU and GPU mining paths use the same final Safe transaction construction.
- Added `wgpu`, `pollster`, `bytemuck`, and `rand` dependencies to the CLI crate.
- Added adapter filtering so software-rendered GPU adapters are not used by default.
- Added a GL backend guard for the current fallback path, where the CLI exits without tearing down the GL miner after a successful run.

## Testing and Validation

This branch adds tests for:

- GPU CLI argument parsing.
- `--list-gpus` behaviour without requiring Safe owner or prefix arguments.
- prefix length validation.
- GPU dispatch-size rounding.
- host-side input and result memory layout.
- shader workgroup size matching the Rust host code.
- GPU nonce derivation for counter byte order and carry behaviour.
- GPU matching across every Ethereum address prefix length from 1 to 20 bytes.
- CPU recomputation of Safe addresses from `SearchContext`.

The GPU tests are written so they skip when no GPU adapter is available. A separate, ignored benchmark test can be run manually to measure GPU throughput.
